### PR TITLE
Recursively ignore all .pyc files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@
 .gitignore
 *.yml
 Dockerfile
-*/__pycache__
+**/*.pyc


### PR DESCRIPTION
as opposed to ignoring `__pycache__` dirs