### PR TITLE
Set branch dev as codecov "master" copy

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: travis
+  branch: dev
   max_report_age: off
 
 coverage:


### PR DESCRIPTION
From codecov docs (https://docs.codecov.io/docs/codecov-yaml#section-master-copy):

The default branch is used to identify:

1. Which branch to cache the repository yaml for UI changes.
2. Which branch is the first branch on the repository dashboard in Codecov.