### PR TITLE
Fix md to rst conversion problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
    [Forking Projects](https://guides.github.com/activities/forking/) if
    needed.)
 
-2. Install [`Docker`](https://docs.docker.com/install/). (For Linux, see
+2. Install [Docker](https://docs.docker.com/install/). (For Linux, see
    [Manage Docker as a non-root user](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
    to run `docker` without `sudo`.)
 
-3. Install [`docker-compose`](https://docs.docker.com/compose/install/).
+3. Install [docker-compose](https://docs.docker.com/compose/install/).
 
 4. Run the tests (the first time will take longer as the image will be built):
 


### PR DESCRIPTION
Hyperlinked text in markdown can be "styled" whereas in ReStructuredText
it seems not. Since the README.md is converted to rst (using the tool
`m2r`) for the docs we need to use simple plain text for hyperlinks.

Related issue: https://github.com/miyakogi/m2r/issues/24