### PR TITLE
Add early exit & verbose mode in shell scripts to Travis CI

### DIFF
--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ev
+
 if [ "${BUILD}" == "tests" ]; then
     codecov -v
 fi

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ev
+
 pip install --upgrade pip
 
 if [ "${BUILD}" == "tests" ]; then

--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ev
+
 BASE_CMD="docker-compose -f .travis.compose.yml run --rm test-hbmpc"
 
 if [ "${BUILD}" == "tests" ]; then


### PR DESCRIPTION
From [Travis CI's docs](https://docs.travis-ci.com/user/customizing-the-build/#implementing-complex-build-steps):

> The `-e` flag causes the script to exit as soon as one command returns a
non-zero exit code. This can be handy if you want whatever script you have
to exit early. It also helps in complex installation scripts where one
failed command wouldn’t otherwise cause the installation to fail.

> The `-v` flag makes the shell print all lines in the script before executing
them, which helps identify which steps failed.

The difference can be seen here: https://travis-ci.org/initc3/HoneyBadgerMPC/jobs/433685350#L590:

```shell
$ .ci/travis-script.sh

BASE_CMD="docker-compose -f .travis.compose.yml run --rm test-hbmpc"
if [ "${BUILD}" == "tests" ]; then
    $BASE_CMD pytest -v --cov=honeybadgermpc --cov-report=term-missing --cov-report=xml
elif [ "${BUILD}" == "flake8" ]; then
    flake8 honeybadgermpc/
elif [ "${BUILD}" == "docs" ]; then
    sphinx-build -W -c docs -b html -d docs/_build/doctrees docs docs/_build/html
fi
Creating network "honeybadgermpc_default" with the default driver
============================= test session starts ==============================
```

... compare with https://travis-ci.org/initc3/HoneyBadgerMPC/jobs/431243486#L579:

```shell
$ .ci/travis-script.sh
Creating network "honeybadgermpc_default" with the default driver
============================= test session starts ==============================
```