### PR TITLE
Simplify the way the docs are built for travis

### DIFF
--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -7,5 +7,5 @@ if [ "${BUILD}" == "tests" ]; then
 elif [ "${BUILD}" == "flake8" ]; then
     flake8 honeybadgermpc/
 elif [ "${BUILD}" == "docs" ]; then
-    sphinx-build -W -c docs -b html -d docs/_build/doctrees docs docs/_build/html
+    sphinx-build -M html docs docs/_build -c docs -W
 fi


### PR DESCRIPTION
This was done so that it is a bit more consistent with the way it is done in the `docs/Makefile`. That is, the `docs/Makefile` has:

```make
@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
```

and the script for travis now has:

```yaml
sphinx-build -M html docs docs/_build -c docs -W
```

where `-c docs -W` are the sphinx options.

----

_Documention of the `sphinx-build` command is at http://www.sphinx-doc.org/en/master/man/sphinx-build.html_
