### PR TITLE
Add sphinx options to docker-compose builddocs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/usr/src/HoneyBadgerMPC
+    environment:
+      - O=-W --keep-going
     command: make -C docs html
   viewdocs:
     image: nginx


### PR DESCRIPTION
Re-doing #68 (see #75):

This allows one to quickly test that the docs are being generated without warnings/errors as it is tested on travis.

The [`--keep-going`](http://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going) option is used so that the docs will be generated despite warnings. This way one can still see what the docs look like.