### PR TITLE
[dont merge] Revert gf

### DIFF
--- a/honeybadgermpc/field.py
+++ b/honeybadgermpc/field.py
@@ -24,7 +24,7 @@ arithmetic one would expect: addition, multiplication, etc.
 
 Defining a field:
 
->>> Zp = GF.get(19)
+>>> Zp = GF(19)
 
 Defining field elements:
 
@@ -62,7 +62,7 @@ prime modulus (see :func:`GF` for more information):
 Field elements from different fields cannot be mixed, you will get a
 type error if you try:
 
->>> Zq = GF.get(17)
+>>> Zq = GF(17)
 >>> z = Zq(2)
 >>> x + z
 Traceback (most recent call last):
@@ -74,6 +74,8 @@ The reason for the slightly confusing error message is that ``x`` and
 """
 
 from gmpy import mpz
+
+_field_cache = {}
 
 
 class FieldsNotIdentical(Exception):
@@ -94,246 +96,268 @@ class FieldElement(object):
     __long__ = __int__
 
 
-class GF(object):
-    _field_cache = {}
-
-    def __init__(self, modulus):
-        self.modulus = modulus
-
-    def __call__(self, value):
-        return GFElement(value, self)
-
-    def __reduce__(self):
-        return (GF.get, (self.modulus,))
-
-    @staticmethod
-    def get(modulus):
-        if modulus in GF._field_cache:
-            return GF._field_cache[modulus]
-
-        if not mpz(modulus).is_prime():
-            raise ValueError("%d is not a prime" % modulus)
-
-        gf = GF(modulus)
-        GF._field_cache[modulus] = gf
-        return gf
+def makeGF(modulus, val):
+    return GF(modulus)(val)
 
 
-class GFElement(FieldElement):
+def GF(modulus):
+    """Generate a Galois (finite) field with the given modulus.
 
-    def __init__(self, value, gf):
-        self.modulus = gf.modulus
-        self.field = gf
-        self.value = value % self.modulus
+    The modulus must be a prime:
 
-    def __add__(self, other):
-        """Addition."""
-        if not isinstance(other, (GFElement, int)):
-            return NotImplemented
-        try:
-            # We can do a quick test using 'is' here since
-            # there will only be one class representing this
-            # field.
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return GFElement(self.value + other.value, self.field)
-        except AttributeError:
-            return GFElement(self.value + other, self.field)
+    >>> Z23 = GF(23) # works
+    >>> Z10 = GF(10) # not a prime
+    Traceback (most recent call last):
+        ...
+    ValueError: 10 is not a prime
 
-    __radd__ = __add__
+    A modulus of 256 is special since it returns the GF(2^8) field
+    even though 256 is no prime:
 
-    def __sub__(self, other):
-        """Subtraction."""
-        if not isinstance(other, (GFElement, int)):
-            return NotImplemented
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return GFElement(self.value - other.value, self.field)
-        except AttributeError:
-            return GFElement(self.value - other, self.field)
+    >>> GF256 = GF(256)
+    >>> print GF256(1)
+    [1]
 
-    def __rsub__(self, other):
-        """Subtraction (reflected argument version)."""
-        return GFElement(other - self.value, self.field)
+    Please note, that if you wish to calculate square roots, the
+    modulus must be a Blum prime (congruent to 3 mod 4):
 
-    def __xor__(self, other):
-        """Xor for bitvalues."""
-        if not isinstance(other, (GFElement, int)):
-            return NotImplemented
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return GFElement(self.value ^ other.value, self.field)
-        except AttributeError:
-            return GFElement(self.value ^ other, self.field)
+    >>> Z17 = GF(17) # 17 % 4 == 1, so 17 is no Blum prime
+    >>> x = Z17(10)
+    >>> x.sqrt()
+    Traceback (most recent call last):
+        ...
+    AssertionError: Cannot compute square root of {10} with modulus 17
+    """
+    if modulus in _field_cache:
+        return _field_cache[modulus]
 
-    def __rxor__(self, other):
-        """Xor for bitvalues (reflected argument version)."""
-        return GFElement(other ^ self.value, self.field)
+    if not mpz(modulus).is_prime():
+        raise ValueError("%d is not a prime" % modulus)
 
-    def __mul__(self, other):
-        """Multiplication."""
-        if not isinstance(other, (GFElement, int)):
-            return NotImplemented
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return GFElement(self.value * other.value, self.field)
-        except AttributeError:
-            return GFElement(self.value * other, self.field)
+    # Define a new class representing the field. This class will be
+    # returned at the end of the function.
+    class GFElement(FieldElement):
 
-    __rmul__ = __mul__
+        def __reduce__(self):
+            return (makeGF, (modulus, self.value))
 
-    def __pow__(self, exponent):
-        """Exponentiation."""
-        return GFElement(pow(self.value, exponent, self.modulus), self.field)
+        def __init__(self, value):
+            self.value = value % self.modulus
 
-    def __neg__(self):
-        """Negation."""
-        return GFElement(-self.value, self.field)
+        def __add__(self, other):
+            """Addition."""
+            if not isinstance(other, (GFElement, int)):
+                return NotImplemented
+            try:
+                # We can do a quick test using 'is' here since
+                # there will only be one class representing this
+                # field.
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return GFElement(self.value + other.value)
+            except AttributeError:
+                return GFElement(self.value + other)
 
-    def __invert__(self):
-        """Inversion.
+        __radd__ = __add__
 
-        Note that zero cannot be inverted, trying to do so
-        will raise a ZeroDivisionError.
-        """
-        if self.value == 0:
-            raise ZeroDivisionError("Cannot invert zero")
+        def __sub__(self, other):
+            """Subtraction."""
+            if not isinstance(other, (GFElement, int)):
+                return NotImplemented
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return GFElement(self.value - other.value)
+            except AttributeError:
+                return GFElement(self.value - other)
 
-        def extended_gcd(a, b):
-            """The extended Euclidean algorithm."""
-            x = 0
-            lastx = 1
-            y = 1
-            lasty = 0
-            while b != 0:
-                quotient = a // b
-                a, b = b, a % b
-                x, lastx = lastx - quotient*x, x
-                y, lasty = lasty - quotient*y, y
-            return (lastx, lasty, a)
+        def __rsub__(self, other):
+            """Subtraction (reflected argument version)."""
+            return GFElement(other - self.value)
 
-        inverse = extended_gcd(self.value, self.modulus)[0]
-        return GFElement(inverse, self.field)
+        def __xor__(self, other):
+            """Xor for bitvalues."""
+            if not isinstance(other, (GFElement, int)):
+                return NotImplemented
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return GFElement(self.value ^ other.value)
+            except AttributeError:
+                return GFElement(self.value ^ other)
 
-    def __div__(self, other):
-        """Division."""
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return self * ~other
-        except AttributeError:
-            return self * ~GFElement(other, self.field)
+        def __rxor__(self, other):
+            """Xor for bitvalues (reflected argument version)."""
+            return GFElement(other ^ self.value)
 
-    __truediv__ = __div__
-    __floordiv__ = __div__
+        def __mul__(self, other):
+            """Multiplication."""
+            if not isinstance(other, (GFElement, int)):
+                return NotImplemented
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return GFElement(self.value * other.value)
+            except AttributeError:
+                return GFElement(self.value * other)
 
-    def __rdiv__(self, other):
-        """Division (reflected argument version)."""
-        return GFElement(other, self.field) / self
+        __rmul__ = __mul__
 
-    __rtruediv__ = __rdiv__
-    __rfloordiv__ = __rdiv__
+        def __pow__(self, exponent):
+            """Exponentiation."""
+            return GFElement(pow(self.value, exponent, self.modulus))
 
-    def sqrt(self):
-        """Square root.
+        def __neg__(self):
+            """Negation."""
+            return GFElement(-self.value)
 
-        No attempt is made the to return the positive square root.
+        def __invert__(self):
+            """Inversion.
 
-        Computing square roots is only possible when the modulus
-        is a Blum prime (congruent to 3 mod 4).
-        """
-        assert self.modulus % 4 == 3, "Cannot compute square " \
-            "root of %s with modulus %s" % (self, self.modulus)
+            Note that zero cannot be inverted, trying to do so
+            will raise a ZeroDivisionError.
+            """
+            if self.value == 0:
+                raise ZeroDivisionError("Cannot invert zero")
 
-        # Because we assert that the modulus is a Blum prime
-        # (congruent to 3 mod 4), there will be no reminder in the
-        # division below.
-        root = pow(self.value, (self.modulus+1)//4, self.modulus)
-        return GFElement(root, self.field)
+            def extended_gcd(a, b):
+                """The extended Euclidean algorithm."""
+                x = 0
+                lastx = 1
+                y = 1
+                lasty = 0
+                while b != 0:
+                    quotient = a // b
+                    a, b = b, a % b
+                    x, lastx = lastx - quotient*x, x
+                    y, lasty = lasty - quotient*y, y
+                return (lastx, lasty, a)
 
-    def bit(self, index):
-        """Extract a bit (index is counted from zero)."""
-        return (self.value >> index) & 1
+            inverse = extended_gcd(self.value, self.modulus)[0]
+            return GFElement(inverse)
 
-    def signed(self):
-        """Return a signed integer representation of the value.
+        def __div__(self, other):
+            """Division."""
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return self * ~other
+            except AttributeError:
+                return self * ~GFElement(other)
 
-        If x > floor(p/2) then subtract p to obtain negative integer.
-        """
-        if self.value > ((self.modulus-1)/2):
-            return self.value - self.modulus
-        else:
+        __truediv__ = __div__
+        __floordiv__ = __div__
+
+        def __rdiv__(self, other):
+            """Division (reflected argument version)."""
+            return GFElement(other) / self
+
+        __rtruediv__ = __rdiv__
+        __rfloordiv__ = __rdiv__
+
+        def sqrt(self):
+            """Square root.
+
+            No attempt is made the to return the positive square root.
+
+            Computing square roots is only possible when the modulus
+            is a Blum prime (congruent to 3 mod 4).
+            """
+            assert self.modulus % 4 == 3, "Cannot compute square " \
+                "root of %s with modulus %s" % (self, self.modulus)
+
+            # Because we assert that the modulus is a Blum prime
+            # (congruent to 3 mod 4), there will be no reminder in the
+            # division below.
+            root = pow(self.value, (self.modulus+1)//4, self.modulus)
+            return GFElement(root)
+
+        def bit(self, index):
+            """Extract a bit (index is counted from zero)."""
+            return (self.value >> index) & 1
+
+        def signed(self):
+            """Return a signed integer representation of the value.
+
+            If x > floor(p/2) then subtract p to obtain negative integer.
+            """
+            if self.value > ((self.modulus-1)/2):
+                return self.value - self.modulus
+            else:
+                return self.value
+
+        def unsigned(self):
+            """Return a unsigned representation of the value"""
             return self.value
 
-    def unsigned(self):
-        """Return a unsigned representation of the value"""
-        return self.value
+        def __repr__(self):
+            return "{%d}" % self.value
+            # return "GFElement(%d)" % self.value
 
-    def __repr__(self):
-        return "{%d}" % self.value
-        # return "GFElement(%d)" % self.value
+        def __str__(self):
+            """Informal string representation.
 
-    def __str__(self):
-        """Informal string representation.
+            This is simply the value enclosed in curly braces.
+            """
+            return "{%d}" % self.unsigned()
 
-        This is simply the value enclosed in curly braces.
-        """
-        return "{%d}" % self.unsigned()
+        def __eq__(self, other):
+            """Equality test."""
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return self.value == other.value
+            except AttributeError:
+                return self.value == other
 
-    def __eq__(self, other):
-        """Equality test."""
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return self.value == other.value
-        except AttributeError:
-            return self.value == other
+        def __ne__(self, other):
+            """Inequality test."""
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                return self.value != other.value
+            except AttributeError:
+                return self.value != other
 
-    def __ne__(self, other):
-        """Inequality test."""
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            return self.value != other.value
-        except AttributeError:
-            return self.value != other
+        def __cmp__(self, other):
+            """Comparison."""
+            try:
+                if self.field is not other.field:
+                    raise FieldsNotIdentical
+                # TODO Replace with (a > b) - (a < b)
+                # see https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons
+                return cmp(self.value, other.value)     # noqa  XXX until above is done
+            except AttributeError:
+                # TODO Replace with (a > b) - (a < b)
+                # see https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons
+                return cmp(self.value, other)   # noqa XXX until above is done
 
-    def __cmp__(self, other):
-        """Comparison."""
-        try:
-            if self.field is not other.field:
-                raise FieldsNotIdentical
-            # TODO Replace with (a > b) - (a < b)
-            # see https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons
-            return cmp(self.value, other.value)     # noqa  XXX until above is done
-        except AttributeError:
-            # TODO Replace with (a > b) - (a < b)
-            # see https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons
-            return cmp(self.value, other)   # noqa XXX until above is done
+        def __hash__(self):
+            """Hash value."""
+            return hash((self.field, self.value))
 
-    def __hash__(self):
-        """Hash value."""
-        return hash((self.field, self.value))
+        def __nonzero__(self):
+            """Truth value testing.
 
-    def __nonzero__(self):
-        """Truth value testing.
+            Returns False if this element is zero, True otherwise.
+            This allows GF elements to be used directly in Boolean
+            formula:
 
-        Returns False if this element is zero, True otherwise.
-        This allows GF elements to be used directly in Boolean
-        formula:
+            >>> bool(GF256(0))
+            False
+            >>> bool(GF256(1))
+            True
+            >>> x = GF256(1)
+            >>> not x
+            False
+            """
+            return self.value != 0
 
-        >>> bool(GF256(0))
-        False
-        >>> bool(GF256(1))
-        True
-        >>> x = GF256(1)
-        >>> not x
-        False
-        """
-        return self.value != 0
+    GFElement.modulus = modulus
+    GFElement.field = GFElement
+
+    _field_cache[modulus] = GFElement
+    return GFElement
 
 
 def FakeGF(modulus):

--- a/honeybadgermpc/passive.py
+++ b/honeybadgermpc/passive.py
@@ -1,6 +1,6 @@
 import asyncio
 from asyncio import Future
-from .field import GF, GFElement
+from .field import GF
 from .polynomial import polynomialsOver
 from .router import simple_router
 import random
@@ -147,10 +147,10 @@ def write_shares(f, modulus, degree, myid, shares):
 def shareInContext(context):
 
     def _binopField(fut, other, op):
-        assert type(other) in [ShareFuture, GFElementFuture, Share, GFElement]
+        assert type(other) in [ShareFuture, GFElementFuture, Share, Field]
         if isinstance(other, ShareFuture) or isinstance(other, Share):
             res = ShareFuture()
-        elif isinstance(other, GFElement) or isinstance(other, GFElementFuture):
+        elif isinstance(other, Field) or isinstance(other, GFElementFuture):
             res = GFElementFuture()
 
         if isinstance(other, Future):
@@ -176,7 +176,7 @@ def shareInContext(context):
             # v is the local value of the share
             if type(v) is int:
                 v = Field(v)
-            assert type(v) is GFElement
+            assert type(v) is Field
             self.v = v
 
         # Publicly reconstruct a shared value
@@ -191,7 +191,7 @@ def shareInContext(context):
         # TODO: add type checks for the operators
         # @typecheck(Share)
         def __add__(self, other):
-            if isinstance(other, GFElement):
+            if isinstance(other, Field):
                 return Share(self.v + other)
             elif isinstance(other, Share):
                 return Share(self.v + other.v)
@@ -211,7 +211,7 @@ def shareInContext(context):
         def __str__(self): return '{%d}' % (self.v)
 
     def _binopShare(fut, other, op):
-        assert type(other) in [ShareFuture, GFElementFuture, Share, GFElement]
+        assert type(other) in [ShareFuture, GFElementFuture, Share, Field]
         res = ShareFuture()
         if isinstance(other, Future):
             def cb(_): return res.set_result(op(fut.result(), other.result()))
@@ -265,7 +265,7 @@ async def runProgramAsTasks(program, N, t):
 #######################
 
 # Fix the field for now
-Field = GF.get(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
+Field = GF(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
 Poly = polynomialsOver(Field)
 
 

--- a/honeybadgermpc/polynomial.py
+++ b/honeybadgermpc/polynomial.py
@@ -1,7 +1,7 @@
 import operator
 import random
 from functools import reduce
-from .field import GF, GFElement
+from .field import GF
 
 
 def strip_trailing_zeros(a):
@@ -44,7 +44,7 @@ def polynomialsOver(field):
             # shares are in the form (x, y=f(x))
             if type(x_recomb) is int:
                 x_recomb = field(x_recomb)
-            assert type(x_recomb) is GFElement
+            assert type(x_recomb) is field
             xs, ys = zip(*shares)
             vector = []
             for i, x_i in enumerate(xs):
@@ -61,7 +61,7 @@ def polynomialsOver(field):
             """
             n = len(ys)
             assert n & (n-1) == 0, "n must be power of two"
-            assert type(omega) is GFElement
+            assert type(omega) is field
             assert omega ** n == 1, "must be an n'th root of unity"
             assert omega ** (n//2) != 1, "must be a primitive n'th root of unity"
             coeffs = [b/n for b in fft_helper(ys, 1/omega, field)]
@@ -69,7 +69,7 @@ def polynomialsOver(field):
 
         def evaluate_fft(self, omega, n):
             assert n & (n-1) == 0, "n must be power of two"
-            assert type(omega) is GFElement
+            assert type(omega) is field
             assert omega ** n == 1, "must be an n'th root of unity"
             assert omega ** (n//2) != 1, "must be a primitive n'th root of unity"
             return fft(self, omega, n)
@@ -159,7 +159,7 @@ def fft(poly, omega, n, seed=None):
 
 
 if __name__ == "__main__":
-    field = GF.get(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
+    field = GF(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
     Poly = polynomialsOver(field)
     poly = Poly.random(degree=7)
     poly = Poly([1, 5, 3, 15, 0, 3])

--- a/honeybadgermpc/rand_batch.py
+++ b/honeybadgermpc/rand_batch.py
@@ -4,7 +4,7 @@ from .field import GF
 from .polynomial import polynomialsOver, get_omega
 
 # Fix the field for now
-Field = GF.get(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
+Field = GF(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
 Poly = polynomialsOver(Field)
 
 #######################################

--- a/honeybadgermpc/secretshare_functionality.py
+++ b/honeybadgermpc/secretshare_functionality.py
@@ -1,6 +1,6 @@
 import asyncio
 import random
-from .field import GF, GFElement
+from .field import GF
 from .polynomial import polynomialsOver
 
 """
@@ -17,7 +17,7 @@ singleton Functionality.
 """
 
 # Fix the field for now
-Field = GF.get(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
+Field = GF(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
 Poly = polynomialsOver(Field)
 
 
@@ -37,7 +37,7 @@ class SecretShare_Functionality(object):
     async def _run(self):
         v = await self.inputFromDealer
         # TODO: allow v to be arbitrary strings, or a parameter?
-        assert type(v) is GFElement
+        assert type(v) is Field
         poly = Poly.random(self.f, y0=v)
         for i in range(self.N):
             # TODO: this needs to be made into an "eventually send"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def triples_files_prefix(sharedata_tmpdir):
 # e.g.: bls12_381_field?
 def GaloisField():
     from honeybadgermpc.field import GF
-    return GF.get(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
+    return GF(0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001)
 
 
 @fixture

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -4,15 +4,15 @@ import operator
 
 def test_multiple_fields():
     from honeybadgermpc.field import GF
-    Field1 = GF.get(17)
-    Field2 = GF.get(7)
+    Field1 = GF(17)
+    Field2 = GF(7)
     assert Field1.modulus == 17
     assert Field2.modulus == 7
 
 
 def test_invalid_operations_on_fields():
     from honeybadgermpc.field import GF, FieldsNotIdentical
-    Field1, Field2 = GF.get(17), GF.get(7)
+    Field1, Field2 = GF(17), GF(7)
     operators = [
         operator.add,
         operator.sub,
@@ -23,5 +23,5 @@ def test_invalid_operations_on_fields():
         operator.eq,
     ]
     for op in operators:
-        with pytest.raises(FieldsNotIdentical):
+        with pytest.raises((TypeError, FieldsNotIdentical)):
             op(Field1(2), Field2(3))


### PR DESCRIPTION
This reverts the style of fields.py back to a function GF() that returns an inner object, instead of having an outer class GF. We switched from function to outer class to make it easier to use generic `pickle` when serializing field objects for sending on sockets. Using `__reduce__` it's possible to make this work either way, so I don't think it makes much difference. I have a slight aesthetic preference towards the original way, with a distinct class for each field.

Caveat: it is possible that there is a difference in performance. The __reduce__ method applied to instances of the inner class (Field elements) may be packaging up both the whole modulus each time, whereas __reduce__ applied to the outer class (the Field itself) only needs to be transmitted once.

Long term we will not want to use pickle for performance anyway, we should be able to do much faster encoding given that we know exactly the kinds of protocol messages we'll send.