### PR TITLE
Ipc parametization and containerization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,9 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+ipc:
+	sh scripts/launch_ipc.sh
+
+ipc-containers:
+	sh scripts/launch_ipc_containers.sh

--- a/conf/hbmpc.ini
+++ b/conf/hbmpc.ini
@@ -1,0 +1,18 @@
+# sample config file
+
+[general]
+# N - total number of parties
+N: 4
+# t - total number of corrupt parties
+t: 1
+
+[addrinfo]
+id: 0
+host: hbmpc_0
+# port to be used for communication between parties
+port: 7000
+
+[peers]
+1: hbmpc_1:7000
+2: hbmpc_2:7000
+3: hbmpc_3:7000

--- a/conf/ipc.network.docker/hbmpc_0.ini
+++ b/conf/ipc.network.docker/hbmpc_0.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 0
+host: hbmpc_0
+port: 7000
+
+[peers]
+1: hbmpc_1:7000
+2: hbmpc_2:7000
+3: hbmpc_3:7000

--- a/conf/ipc.network.docker/hbmpc_1.ini
+++ b/conf/ipc.network.docker/hbmpc_1.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 1
+host: hbmpc_1
+port: 7000
+
+[peers]
+0: hbmpc_0:7000
+2: hbmpc_2:7000
+3: hbmpc_3:7000

--- a/conf/ipc.network.docker/hbmpc_2.ini
+++ b/conf/ipc.network.docker/hbmpc_2.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 2
+host: hbmpc_2
+port: 7000
+
+[peers]
+0: hbmpc_0:7000
+1: hbmpc_1:7000
+3: hbmpc_3:7000

--- a/conf/ipc.network.docker/hbmpc_3.ini
+++ b/conf/ipc.network.docker/hbmpc_3.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 3
+host: hbmpc_3
+port: 7000
+
+[peers]
+0: hbmpc_0:7000
+1: hbmpc_1:7000
+2: hbmpc_2:7000

--- a/conf/ipc.network.local/hbmpc_0.ini
+++ b/conf/ipc.network.local/hbmpc_0.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 0
+host: hbmpc_0
+port: 7000
+
+[peers]
+1: hbmpc_1:7001
+2: hbmpc_2:7002
+3: hbmpc_3:7003

--- a/conf/ipc.network.local/hbmpc_1.ini
+++ b/conf/ipc.network.local/hbmpc_1.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 1
+host: hbmpc_1
+port: 7001
+
+[peers]
+0: hbmpc_0:7000
+2: hbmpc_2:7002
+3: hbmpc_3:7003

--- a/conf/ipc.network.local/hbmpc_2.ini
+++ b/conf/ipc.network.local/hbmpc_2.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 2
+host: hbmpc_2
+port: 7002
+
+[peers]
+0: hbmpc_0:7000
+1: hbmpc_1:7001
+3: hbmpc_3:7003

--- a/conf/ipc.network.local/hbmpc_3.ini
+++ b/conf/ipc.network.local/hbmpc_3.ini
@@ -1,0 +1,13 @@
+[general]
+N: 4
+t: 1
+
+[addrinfo]
+id: 3
+host: hbmpc_3
+port: 7003
+
+[peers]
+0: hbmpc_0:7000
+1: hbmpc_1:7001
+2: hbmpc_2:7002

--- a/honeybadgermpc/config.py
+++ b/honeybadgermpc/config.py
@@ -1,0 +1,44 @@
+"""Module for ``honeybadgermpc``'s configuration.
+
+This module can be used to:
+
+* define default configuration settings
+* load a configuration
+* validate a comfiguration
+
+example of config dict:
+
+code-block:: python
+
+    {
+        'N': 4,
+        't': 1,
+        'nodeid': '0',
+        'host': 'hbmpc_node_0',
+        'port': 23264,
+        'peers': {
+            '1': hbmpc_node_1:23265,
+            '2': hbmpc_node_2:23266,
+            '3': hbmpc_node_3:23267,
+        },
+    }
+"""
+from configparser import ConfigParser
+
+
+def load_config(path):
+    """Read a configuration file given by ``path`` and return a :obj:`dict`."""
+    cfgparser = ConfigParser()
+
+    with open(path) as file_object:
+        cfgparser.read_file(file_object)
+
+    config = {
+        'N': cfgparser.getint('general', 'N'),
+        't': cfgparser.getint('general', 't'),
+        'nodeid': cfgparser.get('addrinfo', 'id'),
+        'host': cfgparser.get('addrinfo', 'host'),
+        'port': cfgparser.getint('addrinfo', 'port'),
+        'peers': dict(cfgparser.items('peers')),
+    }
+    return config

--- a/honeybadgermpc/exceptions.py
+++ b/honeybadgermpc/exceptions.py
@@ -1,0 +1,6 @@
+class HoneyBadgerMPCError(Exception):
+    """Base exception class."""
+
+
+class ConfigurationError(HoneyBadgerMPCError):
+    """Raise for configuration errors."""

--- a/honeybadgermpc/ipc.py
+++ b/honeybadgermpc/ipc.py
@@ -30,6 +30,9 @@ class Senders(object):
             while True:
                 msg = await q.get()
                 if msg is None:
+                    print('Close the connection')
+                    writer.close()
+                    await writer.wait_closed()
                     break
                 # print('SEND %8s [%2d -> %s]' % (msg[1][0], msg[0], recvid))
                 data = pickle.dumps(msg)

--- a/honeybadgermpc/ipc.py
+++ b/honeybadgermpc/ipc.py
@@ -1,7 +1,10 @@
+import os
 import pickle
 import asyncio
 import sys
 import struct
+import socket
+
 from .passive import PassiveMpc
 
 
@@ -12,9 +15,30 @@ class Senders(object):
 
     async def connect(self):
         # Setup all connections first before sending messages
+
+        # XXX BEGIN temporary hack
+        # ``socket.getaddrinfo``, called in open_connection may fail thus causing an
+        # unhandled exception.
+        # A connection management mechanism is needed to that failed connections are
+        # re-tried etc.
+        # Basically nodes should be capable to join when they try to connect but if late
+        # it should not crash the whole thing, or more precisely prevent other nodes
+        # from participating in the protocol.
+        while True:
+            try:
+                addrinfo_list = [
+                    socket.getaddrinfo(self.config[i].ip, self.config[i].port)[0][4]
+                    for i in range(len(self.queues))
+                ]
+            except socket.gaierror:
+                continue
+            else:
+                break
+        # XXX END temporary hack
+
         streams = [asyncio.open_connection(
-                self.config[i].ip,
-                self.config[i].port
+                addrinfo_list[i][0],
+                addrinfo_list[i][1],
             ) for i in range(len(self.queues))]
         streams = await asyncio.gather(*streams)
         writers = [stream[1] for stream in streams]
@@ -140,7 +164,10 @@ async def runProgramAsProcesses(program, config, t, id):
     send, recv, sender, listener = setup_sockets(config, len(config), id)
     # Need to give time to the listener coroutine to start
     #  or else the sender will get a connection refused.
-    await asyncio.sleep(1)
+
+    # XXX HACK! Increase wait time. Must find better way if possible -- e.g:
+    # try/except retry logic ...
+    await asyncio.sleep(2)
     await sender.connect()
     await asyncio.sleep(1)
     context = PassiveMpc('sid', N, t, id, send, recv, program)
@@ -155,16 +182,35 @@ async def runProgramAsProcesses(program, config, t, id):
 if __name__ == "__main__":
     from .passive import generate_test_zeros, generate_test_triples
     from .passive import test_prog1, test_prog2
+    from .exceptions import ConfigurationError
+    from .config import load_config
 
-    # N - total number of parties
-    # t - total number of corrupt parties
-    # port - port to be used for communication between parties
-    # host_id - Of the form <prefix>_<party_id>
-    N, t, port = int(sys.argv[1]), int(sys.argv[2]), 7000
-    host = sys.argv[3].split("_")
-    prefix, id = host[0] + "_", int(host[1])
+    configfile = os.environ.get('HBMPC_CONFIG')
+
+    # override configfile if passed to command
+    try:
+        configfile = sys.argv[1]
+    except IndexError:
+        pass
+
+    if not configfile:
+        raise ConfigurationError('Environment variable `HBMPC_CONFIG` must be set'
+                                 ' or a config file must be given as first argument.')
+
+    config_dict = load_config(configfile)
+    N = config_dict['N']
+    t = config_dict['t']
+    nodeid = int(config_dict['nodeid'])
+    host = config_dict['host']
+    port = config_dict['port']
+    network_info = {
+        int(peerid): NodeDetails(addrinfo.split(':')[0], int(addrinfo.split(':')[1]))
+        for peerid, addrinfo in config_dict['peers'].items()
+    }
+    network_info[nodeid] = NodeDetails(host, port)
+
     # Only one party needs to generate the initial shares
-    if id == 0:
+    if nodeid == 0:
         print('Generating random shares of zero in sharedata/')
         generate_test_zeros('sharedata/test_zeros', 1000, N, t)
         print('Generating random shares of triples in sharedata/')
@@ -174,8 +220,9 @@ if __name__ == "__main__":
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
     try:
-        config = {i: NodeDetails(prefix+str(i), port+i) for i in range(N)}
-        loop.run_until_complete(runProgramAsProcesses(test_prog1, config, t, id))
-        loop.run_until_complete(runProgramAsProcesses(test_prog2, config, t, id))
+        loop.run_until_complete(
+            runProgramAsProcesses(test_prog1, network_info, t, nodeid))
+        loop.run_until_complete(
+            runProgramAsProcesses(test_prog2, network_info, t, nodeid))
     finally:
         loop.close()

--- a/honeybadgermpc/ipc.py
+++ b/honeybadgermpc/ipc.py
@@ -22,7 +22,7 @@ class Senders(object):
         # Setup tasks to consume messages from queues
         # This is to ensure that messages are delivered in the correct order
         for i, q in enumerate(self.queues):
-            recvid = "%s:%d" % (config[i].ip, config[i].port)
+            recvid = "%s:%d" % (self.config[i].ip, self.config[i].port)
             asyncio.ensure_future(self.process_queue(writers[i], q, recvid))
 
     async def process_queue(self, writer, q, recvid):

--- a/network.yml
+++ b/network.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+services:
+  hbmpc_0:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/usr/src/HoneyBadgerMPC
+    environment:
+      HBMPC_CONFIG: conf/ipc.network.docker/hbmpc_0.ini
+    command: python -m honeybadgermpc.ipc
+  hbmpc_1:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/usr/src/HoneyBadgerMPC
+    environment:
+      HBMPC_CONFIG: conf/ipc.network.docker/hbmpc_1.ini
+    command: python -m honeybadgermpc.ipc
+  hbmpc_2:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/usr/src/HoneyBadgerMPC
+    environment:
+      HBMPC_CONFIG: conf/ipc.network.docker/hbmpc_2.ini
+    command: python -m honeybadgermpc.ipc
+  hbmpc_3:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/usr/src/HoneyBadgerMPC
+    environment:
+      HBMPC_CONFIG: conf/ipc.network.docker/hbmpc_3.ini
+    command: python -m honeybadgermpc.ipc

--- a/scripts/launch_ipc.sh
+++ b/scripts/launch_ipc.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Assume hosts are as follows:
+"""
+ 127.0.0.1   hbmpc_0
+ 127.0.0.1   hbmpc_1
+ 127.0.0.1   hbmpc_2
+ 127.0.0.1   hbmpc_3
+"""
+
+CMD="python -m honeybadgermpc.ipc"
+CONFIG_PATH=conf/ipc.network.local
+set -x
+tmux new-session     "${CMD} ${CONFIG_PATH}/hbmpc_0.ini; sh" \; \
+     splitw -h -p 50 "${CMD} ${CONFIG_PATH}/hbmpc_1.ini; sh" \; \
+     splitw -v -p 50 "${CMD} ${CONFIG_PATH}/hbmpc_2.ini; sh" \; \
+     selectp -t 0 \; \
+     splitw -v -p 50 "${CMD} ${CONFIG_PATH}/hbmpc_3.ini; sh"

--- a/scripts/launch_ipc_containers.sh
+++ b/scripts/launch_ipc_containers.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
-# Assume hosts are as follows:
-"""
- 127.0.0.1   hbmpc_0
- 127.0.0.1   hbmpc_1
- 127.0.0.1   hbmpc_2
- 127.0.0.1   hbmpc_3
-"""
 
-CMD="python -m honeybadgermpc.ipc 4 1"
 set -x
+
+CMD="docker-compose -f network.yml up"
+
+docker-compose -f network.yml rm -sf
+
 tmux new-session     "${CMD} hbmpc_0; sh" \; \
      splitw -h -p 50 "${CMD} hbmpc_1; sh" \; \
      splitw -v -p 50 "${CMD} hbmpc_2; sh" \; \

--- a/tests/test_simple_router.py
+++ b/tests/test_simple_router.py
@@ -1,5 +1,4 @@
 import asyncio
-import random
 
 from pytest import mark
 


### PR DESCRIPTION
This PR proposes some changes to `ipc.py` which allows its execution in containerized environments.

The usage of a simple config file was also introduced in order to simply the ipc main command's arguments.

Using the localhost -based approach via `launch_ipc.sh` remains unchanged in terms of usage, except that the script was moved under `scripts/` i.e.: `sh scripts/launch_ipc.sh`,

To simplify the usage two `make` targets were introduced: `ipc` and `ipc-containers`:

Run the nodes on localhost:

```console
$ make ipc 
```

Run the nodes in separate containers:

```console
$ make ipc-containers
````

It is also possible to use `docker-compose` directly:

```console
$ docker-compose -f network.yml up
```

The above displays the logs of each container/node in a sequential manner in one shell.