### PR TITLE
Fix dup event loop

### DIFF
--- a/tests/test_commonsubset_functionality.py
+++ b/tests/test_commonsubset_functionality.py
@@ -1,3 +1,7 @@
-def test_acs_ideal_():
-    from honeybadgermpc.commonsubset_functionality import test_acs_ideal
-    test_acs_ideal()
+from pytest import mark
+
+
+@mark.asyncio
+async def test_acs_ideal_():
+    from honeybadgermpc.commonsubset_functionality import _test_acs_ideal
+    await _test_acs_ideal()

--- a/tests/test_rand_batch.py
+++ b/tests/test_rand_batch.py
@@ -1,3 +1,7 @@
-def test_rand_():
-    from honeybadgermpc.rand_batch import test_rand
-    test_rand()
+from pytest import mark
+
+
+@mark.asyncio
+async def test_rand_():
+    from honeybadgermpc.rand_batch import _test_rand
+    await _test_rand()

--- a/tests/test_rand_functionality.py
+++ b/tests/test_rand_functionality.py
@@ -1,3 +1,7 @@
-def test_sharesingle_ideal_():
-    from honeybadgermpc.rand_functionality import test_sharesingle_ideal
-    test_sharesingle_ideal()
+from pytest import mark
+
+
+@mark.asyncio
+async def test_sharesingle_ideal_():
+    from honeybadgermpc.rand_functionality import _test_sharesingle_ideal
+    await _test_sharesingle_ideal()

--- a/tests/test_rand_protocol.py
+++ b/tests/test_rand_protocol.py
@@ -1,8 +1,13 @@
-def test_naive_():
-    from honeybadgermpc.rand_protocol import test_naive
-    test_naive()
+from pytest import mark
 
 
-def test_rand_():
-    from honeybadgermpc.rand_protocol import test_rand
-    test_rand()
+@mark.asyncio
+async def test_naive_():
+    from honeybadgermpc.rand_protocol import _test_naive
+    await _test_naive()
+
+
+@mark.asyncio
+async def test_rand_():
+    from honeybadgermpc.rand_protocol import _test_rand
+    await _test_rand()

--- a/tests/test_secretshare_functionality.py
+++ b/tests/test_secretshare_functionality.py
@@ -2,6 +2,6 @@ from pytest import mark
 
 
 @mark.asyncio
-async def test(event_loop):
+async def test():
     from honeybadgermpc.secretshare_functionality import test1
     await test1()


### PR DESCRIPTION
:smile: 

A bit complicated to explain why ... will try to do so later.

But perhaps, at the risk of oversimplifying:

It is either pytest-asyncio all the way when async is on, or not at all (e.g.: managing the loop ourselves like it was done in some tests, especially the closing part). 