### PR TITLE
Makes batch reconstruction faster

### DIFF
--- a/honeybadgermpc/polynomial.py
+++ b/honeybadgermpc/polynomial.py
@@ -57,18 +57,26 @@ def polynomialsOver(field):
                 vector.append(reduce(operator.mul, factors))
             return sum(map(operator.mul, ys, vector))
 
+        _lagrangeCache = {}  # Cache lagrange polynomials
+
         @classmethod
         def interpolate(cls, shares):
-            X = cls([0, 1])  # This is the polynomial f(x) = x
-            ONE = cls([1])  # This is the polynomial f(x) = 1
+            X = cls([field(0), field(1)])  # This is the polynomial f(x) = x
+            ONE = cls([field(1)])  # This is the polynomial f(x) = 1
             xs, ys = zip(*shares)
 
             def lagrange(xi):
+                # Let's cache lagrange values
+                if (xs, xi) in cls._lagrangeCache:
+                    return cls._lagrangeCache[(xs, xi)]
+
                 def mul(a, b): return a*b
                 num = reduce(mul, [X - cls([xj])
                                    for xj in xs if xj != xi], ONE)
                 den = reduce(mul, [xi - xj for xj in xs if xj != xi], field(1))
-                return num * cls([1 / den])
+                p = num * cls([1 / den])
+                cls._lagrangeCache[(xs, xi)] = p
+                return p
             f = cls([0])
             for xi, yi in zip(xs, ys):
                 pi = lagrange(xi)

--- a/honeybadgermpc/wb_interpolate.py
+++ b/honeybadgermpc/wb_interpolate.py
@@ -129,11 +129,11 @@ def makeEncoderDecoder(n, k, p, omega=None):
     def decode(encodedMessage, debug=False):
         assert(len(encodedMessage) == n)
         c = sum(m is None for m in encodedMessage)  # number of erasures
-        assert(t + 1 + c <= n)
-        e = (n - c - t - 1) // 2  # number of errors to correct
+        assert(2*t + 1 + c <= n)
+        e = (n - c - (2 * t + 1))  # number of errors to correct
 
         if debug:
-            print('n:', n, 'k:', k, 't:', t)
+            print('n:', n, 'k:', k, 't:', t, 'c:', c)
             print('decoding with e:', e)
             print('decoding with c:', c)
 

--- a/tests/test_wb_interpolate.py
+++ b/tests/test_wb_interpolate.py
@@ -21,13 +21,13 @@ def test_decoding():
     assert(decoded == integerMessage)
 
     # Corrupt with maximum number of erasures:
-    cMax = n - t - 1
+    cMax = n - 2 * t - 1
     corrupted = corrupt(encoded, numErrors=0, numNones=cMax)
     coeffs = dec(corrupted, debug=False)
     assert coeffs == integerMessage
 
     # Corrupt with maximum number of errors:
-    eMax = (n - t - 1) // 2
+    eMax = (n - 2 * t - 1) // 2
     corrupted = corrupt(encoded, numErrors=eMax, numNones=0)
     coeffs = dec(corrupted, debug=False)
     assert coeffs == integerMessage


### PR DESCRIPTION
This is an optimization found after profiling, as mentioned in #22 
This fixes an error causing RS decoding to be used instead of plain interpolation.
Also, interpolation is slow because it recomputes the same lagrange polynomials over and over. This introduces a patch.