### PR TITLE
Reuse input across runs on AWS

### DIFF
--- a/apps/shuffle/butterfly_network.py
+++ b/apps/shuffle/butterfly_network.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
         for peerid, addrinfo in config_dict['peers'].items()
     }
 
-    inputs = [Field(i) for i in range(1, k+1)]
+    inputs = [Field(random.randint(0, Field.modulus-1)) for _ in range(k)]
 
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()

--- a/apps/shuffle/powermixing.py
+++ b/apps/shuffle/powermixing.py
@@ -2,6 +2,7 @@ import random
 import asyncio
 import uuid
 import os
+import glob
 from time import time
 from honeybadgermpc.mpc import write_polys, TaskProgramRunner, Field, Poly
 from honeybadgermpc.logger import BenchmarkLogger
@@ -211,7 +212,7 @@ async def asynchronusMixingInProcesses(network_info, N, t, k, runid, nodeid):
     result = solve([s.value for s in powerSums])
     benchLogger.info(f"[SolverPhase] Run Newton Solver: {time() - stime}")
     print(f"Equation solver completed.")
-    print(result)
+    # print(result)
     return result
 
 
@@ -271,6 +272,12 @@ if __name__ == "__main__":
 
     loop.set_exception_handler(handle_async_exception)
     loop.set_debug(True)
+
+    # Cleanup pre existing sums file
+    sums_file = glob.glob(f'{sharedatadir}/*.sums')
+    for f in sums_file:
+        os.remove(f)
+
     try:
         if not config_dict['skipPreprocessing']:
             # Need to keep these fixed when running on processes.
@@ -281,8 +288,6 @@ if __name__ == "__main__":
 
             if nodeid == 0:
                 os.makedirs("sharedata/", exist_ok=True)
-                loop.run_until_complete(
-                    runCommandSync(f"rm -f {sharedatadir}/**"))
                 for i, a in enumerate(a_s):
                     batchid = f"{runid}_{i}"
                     generate_test_powers(

--- a/aws/AWSConfig.py
+++ b/aws/AWSConfig.py
@@ -1,4 +1,6 @@
 import json
+import os
+import sys
 
 
 class RegionConfig(object):
@@ -21,6 +23,15 @@ class MPCConfig(object):
         self.n = n
 
 
+def read_environment_variable(key):
+    try:
+        value = os.environ[key]
+    except KeyError:
+        print(f">>> {key} environment variable not set.")
+        sys.exit(1)
+    return value
+
+
 class AwsConfig:
     config = json.load(open('./aws/aws-config.json'))
 
@@ -36,10 +47,8 @@ class AwsConfig:
     )
 
     awsconfig = config["aws"]
-    credentials = json.load(open(awsconfig["credentials_file_path"]))
-    ACCESS_KEY_ID = credentials["access_key_id"]
-    SECRET_ACCESS_KEY = credentials["secret_access_key"]
-
+    ACCESS_KEY_ID = read_environment_variable("ACCESS_KEY_ID")
+    SECRET_ACCESS_KEY = read_environment_variable("SECRET_ACCESS_KEY")
     SETUP_FILE_PATH = awsconfig["setup_file_path"]
 
     REGION = {}

--- a/aws/README.md
+++ b/aws/README.md
@@ -6,13 +6,9 @@
 
 # Configuration
 1. This code pulls the docker image with tag:`latest` from [here](https://hub.docker.com/r/smkuls/honeybadgermpc/tags/). In order to replace the docker image, update `image_path` in `aws-config.json` with the appropriate image.
-2. Create a file with `.secret.json` extension (eg: `credentials.secret.json`) containing AWS credentials with the following structure:
-```
-{
-    "access_key_id": "",
-    "secret_access_key": ""
-}
-```
+2. Make sure you have the following two environment variables set to appropriate values. Please use the export command if you are setting them within the container. Eg: `export <key>=<value>`.
+    1. `ACCESS_KEY_ID` - Set this to your AWS access key id.
+    2. `SECRET_ACCESS_KEY` - Set this to your AWS secret acces key.
 3. The description of the config is as follows. Update keys accordingly.
     1. `mpc`: This contains configuration for the MPC application.
         1. `command`: The command to run to trigger the MPC application.
@@ -20,18 +16,17 @@
         3. `port`: Port on which the node is listening.
         4. `num_triples`: Number of triples which need to be generated in the preprocessing phase.
     2. `aws`: AWS related configuration.
-        1. `credentials_file_path`: Path to the AWS credentials file created in Step 1. Must end in `.secret.json`. This is to avoid accidentally checking in the file.
-        2. `setup_file_path`: Path to a shell script which contains all commands required to be run when starting up the instance.
-        3. `region`: Contains AWS region specific information.
+        1. `setup_file_path`: Path to a shell script which contains all commands required to be run when starting up the instance.
+        2. `region`: Contains AWS region specific information.
             1. `vm_count`: Number of VMs to be created in this region.
             2. `security_group_ids`: Security groups to be associated with instances of this region. These security groups must pre-exist and should allow all traffic.
             3. `image_id`: AMI of an image for Ubuntu 18.04 LTS for this region.
             4. `key_file_path`: Path to the private key in order to SSH into the instances of this region. Make sure that the permissions of the key pair are `400`.
             5. `key_name`: Name of the key pair present in this region in order to SSH into the instances.
-        4. `vm_name`: Name of the VM to allow to distinguish them on the AWS console. All VMs will have the same name.
-        5. `instance_type`: Size of the instances.
-        6. `instance_user_name`: For an Ubuntu AMI, this is `ubuntu`. Make sure to update this if a different OS is used for the instances.
-        7. `bucket_name`: Name of the bucket in S3 where the config files will be stored. If the bucket doesn't exist, it will be created. AWS requires bucket names to be unique across all users so if the bucket creation fails specify another unique name.
+        3. `vm_name`: Name of the VM to allow to distinguish them on the AWS console. All VMs will have the same name.
+        4. `instance_type`: Size of the instances.
+        5. `instance_user_name`: For an Ubuntu AMI, this is `ubuntu`. Make sure to update this if a different OS is used for the instances.
+        6. `bucket_name`: Name of the bucket in S3 where the config files will be stored. If the bucket doesn't exist, it will be created. AWS requires bucket names to be unique across all users so if the bucket creation fails specify another unique name.
     3. `docker`:
         1. `image_path`: Path to the docker image along with the tag on DockerHub.
 

--- a/aws/s3Manager.py
+++ b/aws/s3Manager.py
@@ -41,11 +41,12 @@ class S3Manager(object):
             Prefix=self.prefix
         )
         keysToDelete = []
-        for obj in response['Contents']:
-            keysToDelete.append({'Key': obj["Key"]})
-        self.s3Client.delete_objects(
-            Bucket=self.bucket,
-            Delete={
-                'Objects': keysToDelete
-            }
-        )
+        if 'Contents' in response:
+            for obj in response['Contents']:
+                keysToDelete.append({'Key': obj["Key"]})
+            self.s3Client.delete_objects(
+                Bucket=self.bucket,
+                Delete={
+                    'Objects': keysToDelete
+                }
+            )


### PR DESCRIPTION
* Move AWS credentials from file to environment variable.
* Provide options to run `run-on-ec2.py` in setup only, skip setup and
full mode. This allows the user to reuse the setup files which were
uploaded for a larger k for any consecutive runs with a smaller k.