### PR TITLE
Butterfly network and batch reconstruct fixes

### DIFF
--- a/aws/run-on-ec2.py
+++ b/aws/run-on-ec2.py
@@ -107,7 +107,8 @@ def getIpcCommands(s3Manager, instanceIds):
 
 
 def getButterflyNetworkCommands(max_k, s3Manager, instanceIds):
-    from honeybadgermpc.mpc import generate_test_triples
+    from honeybadgermpc.mpc import (
+        generate_test_triples, generate_test_randoms, random_files_prefix)
     from apps.shuffle.butterfly_network import generate_random_shares, oneminusoneprefix
     from math import log
 
@@ -117,8 +118,11 @@ def getButterflyNetworkCommands(max_k, s3Manager, instanceIds):
     numTriples = AwsConfig.MPC_CONFIG.NUM_TRIPLES
     generate_test_triples('sharedata/test_triples', numTriples, N, t)
     generate_random_shares(oneminusoneprefix, k * int(log(k, 2)), N, t)
+    generate_test_randoms(random_files_prefix, 5000, N, t)
     tripleUrls = [s3Manager.uploadFile(
         "sharedata/test_triples-%d.share" % (i)) for i in range(N)]
+    inputUrls = [s3Manager.uploadFile(
+        f"{random_files_prefix}-%d.share" % (i)) for i in range(N)]
     randShareUrls = [s3Manager.uploadFile(
         f"{oneminusoneprefix}-{i}.share") for i in range(N)]
     setupCommands = [[instanceId, [
@@ -126,6 +130,7 @@ def getButterflyNetworkCommands(max_k, s3Manager, instanceIds):
             "mkdir -p sharedata",
             "cd sharedata; curl -sSO %s" % (tripleUrls[i]),
             "cd sharedata; curl -sSO %s" % (randShareUrls[i]),
+            "cd sharedata; curl -sSO %s" % (inputUrls[i]),
             "mkdir -p benchmark",
         ]] for i, instanceId in enumerate(instanceIds)]
 

--- a/tests/test_butterfly_network.py
+++ b/tests/test_butterfly_network.py
@@ -1,29 +1,32 @@
 import asyncio
 from pytest import mark
 from math import log
-import random
 
 
 @mark.asyncio
 async def test_butterfly_network(sharedatadir):
     import apps.shuffle.butterfly_network as butterfly
-    from honeybadgermpc.mpc import generate_test_triples, Field, TaskProgramRunner
+    from honeybadgermpc.mpc import TaskProgramRunner
+    from honeybadgermpc.mpc import (
+        generate_test_triples, generate_test_randoms, random_files_prefix)
 
     async def verify_output(ctx, **kwargs):
-        print(kwargs)
-        k, delta, inputs = kwargs['k'], kwargs['delta'], kwargs['inputs']
-        shares = await butterfly.butterflyNetwork(ctx, k=k, delta=delta, inputs=inputs)
+        k, delta = kwargs['k'], kwargs['delta']
+        inputs = ctx.read_shares(open(f"{random_files_prefix}-{ctx.myid}.share"))[:k]
+        sortedinput = sorted(await ctx.ShareArray(inputs).open(), key=lambda x: x.value)
+
+        shares = await butterfly.butterflyNetwork(ctx, k=k, delta=delta)
         outputs = await asyncio.gather(*[s.open() for s in shares])
-        assert len(inputs) == len(outputs)
-        sortedinput = sorted(inputs, key=lambda x: x.value)
+
+        assert len(sortedinput) == len(outputs)
         sortedoutput = sorted(outputs, key=lambda x: x.value)
         for i, j in zip(sortedinput, sortedoutput):
             assert i == j
 
     N, t, k, delta = 3, 1, 32, -9999
+    generate_test_randoms(random_files_prefix, 1000, N, t)
     butterfly.generate_random_shares(butterfly.oneminusoneprefix, k*int(log(k, 2)), N, t)
     generate_test_triples(butterfly.triplesprefix, 1000, N, t)
-    inputs = [Field(random.randint(0, Field.modulus-1)) for _ in range(k)]
     programRunner = TaskProgramRunner(N, t)
-    programRunner.add(verify_output,  k=k, delta=delta, inputs=inputs)
+    programRunner.add(verify_output,  k=k, delta=delta)
     await programRunner.join()


### PR DESCRIPTION
Make butterfly network always switch a batch size of k//2. Earlier each
recursive call was getting a smaller input to operate on and thus the size of the
batch which was being switched was less than k//2 thereby incurring
additional communication overhead.