### PR TITLE
Run HoneyBadgerMPC tests only and skip charm tests

### DIFF
--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -5,7 +5,8 @@ set -ev
 BASE_CMD="docker-compose -f .travis.compose.yml run --rm test-hbmpc"
 
 if [ "${BUILD}" == "tests" ]; then
-    $BASE_CMD pytest -v --cov=honeybadgermpc --cov-report=term-missing --cov-report=xml
+    # Run only hbmpc test cases present within the `tests` directory.
+    $BASE_CMD pytest -v tests/ --cov=honeybadgermpc --cov-report=term-missing --cov-report=xml
 elif [ "${BUILD}" == "flake8" ]; then
     flake8
 elif [ "${BUILD}" == "docs" ]; then

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ lint: ## check style with flake8
 	flake8 honeybadgermpc tests
 
 test: ## run tests quickly with the default Python
-	pytest -v
+	pytest -v tests/
 
 test-all: ## run tests on every Python version with tox
 	tox
 
 coverage: ## check code coverage quickly with the default Python
-	pytest -v -n auto --cov=honeybadgermpc --cov-report term --cov-report html
+	pytest -v tests/ -n auto --cov=honeybadgermpc --cov-report term --cov-report html
 	$(BROWSER) htmlcov/index.html
 
 docs: ## generate Sphinx HTML documentation, including API docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - ./pairing/Cargo.toml:/usr/src/HoneyBadgerMPC/pairing/Cargo.toml
       - ./pairing/setup.py:/usr/src/HoneyBadgerMPC/pairing/setup.py
       - /usr/src/HoneyBadgerMPC/honeybadgermpc/ntl  # Directory _not_ mounted from host
-    command: pytest -v --cov=honeybadgermpc
+    command: pytest -v tests/ --cov=honeybadgermpc
     extra_hosts:
       - "hbmpc_0:127.0.0.1"
       - "hbmpc_1:127.0.0.1"

--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -114,7 +114,7 @@ the end of the ``script`` step, with the ``--cov-report=xml`` option:
 .. code-block:: bash
 
     # .ci/travis-install.sh
-    $BASE_CMD pytest -v --cov --cov-report=term-missing --cov-report=xml
+    $BASE_CMD pytest -v tests/ --cov --cov-report=term-missing --cov-report=xml
 
 If the test run was successful the report is uploaded to `codecov`_ in the
 ``after_success`` step:

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -99,7 +99,7 @@ Run the test:
 
 .. code-block:: shell-session
 
-    $ pytest -v tests/test_passive.py -s
+    $ pytest -v tests/test_mpc.py -s
 
 or
 
@@ -163,7 +163,7 @@ Managing your development environment with Pipenv
 
    .. code-block:: shell-session
 
-       $ pytest -v --cov
+       $ pytest -v tests/ --cov
 
 The tests should pass, and you should also see a small code coverage report
 output to the terminal.
@@ -187,22 +187,22 @@ Running in verbose mode:
 
 .. code-block:: shell-session
 
-    $ pytest -v
+    $ pytest -v tests/
 
 Running a specific test:
 
 .. code-block:: shell-session
 
-    $ pytest -v tests/test_passive.py::test_open_share
+    $ pytest -v tests/test_mpc.py::test_open_shares
 
 When debugging, i.e. if one has put breakpoints in the code, use the ``-s``
 option (or its equivalent ``--capture=no``):
 
 .. code-block:: shell-session
 
-    $ pytest -v -s
+    $ pytest -v tests/ -s
     # or
-    $ pytest -v --capture=no
+    $ pytest -v tests/ --capture=no
 
 To exit instantly on first error or failed test:
 


### PR DESCRIPTION
After adding `charm` as a dependency `pytest -v` also triggers charm's
test cases which prolong the CI time. This PR skips the charm's tests
and runs only the tests written within the `tests/` directory.