### PR TITLE
Skip charm tests and run only HoneyBadgerMPC tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 log_level = DEBUG
 log_file = tests/.pytest.log
 log_file_level = DEBUG
+norecursedirs = charm
 
 # depends on pytest-env plugin ()
 env = 


### PR DESCRIPTION
After adding `charm` as a dependency `pytest -v` also triggers `charm's` test cases which causes the CI to take longer thereby increasing the PR time. This change prevents `charm's` test cases to be run with `pytest -v`.