### PR TITLE
Some fixes to AWS code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ Dockerfile
 **/*.pyc
 sharedata/**
 aws/
+conf/

--- a/aws/AWSConfig.py
+++ b/aws/AWSConfig.py
@@ -13,14 +13,14 @@ class RegionConfig(object):
 
 
 class MPCConfig(object):
-    def __init__(self, command, t, k, delta, port, num_triples, n):
+    def __init__(self, command, t, k, port, num_triples, n, num_faulty_nodes):
         self.COMMAND = command
         self.T = t
         self.PORT = port
         self.NUM_TRIPLES = num_triples
         self.K = k
-        self.DELTA = delta
-        self.n = n
+        self.N = n
+        self.NUM_FAULTY_NODES = num_faulty_nodes
 
 
 def read_environment_variable(key):
@@ -36,14 +36,18 @@ class AwsConfig:
     config = json.load(open('./aws/aws-config.json'))
 
     mpc_config = config["mpc"]
+
+    assert mpc_config["num_faulty_nodes"] <= mpc_config["t"], ("`num_faulty_nodes` \
+        cannot be greater than `t`")
+
     MPC_CONFIG = MPCConfig(
         mpc_config["command"],
         mpc_config["t"],
         mpc_config["k"],
-        mpc_config["delta"],
         mpc_config["port"],
         mpc_config["num_triples"],
-        mpc_config["n"]
+        mpc_config["n"],
+        mpc_config["num_faulty_nodes"],
     )
 
     awsconfig = config["aws"]

--- a/aws/__init__.py
+++ b/aws/__init__.py
@@ -1,0 +1,8 @@
+import logging.config
+import yaml
+
+
+with open('honeybadgermpc/logging.yaml', 'r') as f:
+    logging_config = yaml.safe_load(f.read())
+    logging.config.dictConfig(logging_config)
+    logging.getLogger('paramiko').setLevel(logging.WARNING)

--- a/aws/aws-config.json
+++ b/aws/aws-config.json
@@ -4,10 +4,9 @@
         "t": 1,
         "n": 4,
         "k": 8,
-        "port": 7000,
-        "delta": -999,
+        "num_faulty_nodes": 0,
         "num_triples": 1000,
-        "skipPreProcessing" : true
+        "port": 7000
     },
 
     "aws":{

--- a/aws/delete_vms.py
+++ b/aws/delete_vms.py
@@ -1,23 +1,25 @@
 import os
+import logging
 from aws.ec2Manager import EC2Manager
 
 
 if __name__ == "__main__":
     ec2manager = EC2Manager()
     if os.path.isfile(EC2Manager.current_vms_file_name):
-        print("Do you want to terminate all VMs with the ids:",
-              ec2manager.get_current_vm_instance_ids(), "(y/n)?")
+        logging.info(
+            f"Do you want to terminate all VMs with the ids: \
+                {ec2manager.get_current_vm_instance_ids()} (y/n)?")
 
         while True:
             choice = input()
             if choice.lower() == "y":
                 ec2manager.terminate_instances_by_id()
-                print("Termination triggered successfully!")
+                logging.info("Termination triggered successfully!")
                 break
             elif choice.lower() == "n":
-                print("Termination not triggered.")
+                logging.info("Termination not triggered.")
                 break
             else:
-                print("Invalid option, reenter.")
+                logging.info("Invalid option, reenter.")
     else:
-        print("No VMs to delete.")
+        logging.info("No VMs to delete.")

--- a/aws/ec2Manager.py
+++ b/aws/ec2Manager.py
@@ -1,6 +1,7 @@
 import boto3
 import paramiko
 import os.path
+import logging
 from threading import Semaphore
 from aws.AWSConfig import AwsConfig
 
@@ -37,10 +38,10 @@ class EC2Manager:
 
     def create_instances(self):
         if os.path.isfile(EC2Manager.current_vms_file_name):
-            print(">>> Picking up VMs from current.vms file. <<<")
+            logging.info("Picking up VMs from current.vms file.")
             all_instance_ids = self.get_current_vm_instance_ids()
         else:
-            print(">>> VM creation started. <<<")
+            logging.info("VM creation started.")
             all_instance_ids = []
             region_instance_id_map = {}
             for region, region_config in AwsConfig.REGION.items():
@@ -91,7 +92,7 @@ class EC2Manager:
 
             with open(EC2Manager.current_vms_file_name, "w") as file_handle:
                 file_handle.write(",".join(all_instance_ids))
-            print(">>> VMs successfully booted up. <<<")
+            logging.info("VMs successfully booted up.")
         all_instance_ips = [self.get_instance_public_ip(id) for id in all_instance_ids]
         self.instanceIdToNodeIdMap = {id: i for i, id in enumerate(all_instance_ids)}
         return all_instance_ids, all_instance_ips
@@ -138,7 +139,7 @@ class EC2Manager:
                         print(
                             f"{'#'*10} OUTPUT FROM {ip} | Command: {command} {'#'*10}"
                         )
-                        print(output)
+                        logging.info(output)
                         print("#" * 30)
                     if output_file_prefix:
                         with open(

--- a/honeybadgermpc/mpc.py
+++ b/honeybadgermpc/mpc.py
@@ -393,7 +393,7 @@ async def test_prog1(context):
     x_, y_, xy_ = await x.open(), await y.open(), await xy.open()
     assert x_ * y_ == xy_
 
-    logging.info(f"[%d] Finished {context.myid}, {x_}, {y_}, {xy_}")
+    logging.info(f"[{context.myid}] Finished {x_}, {y_}, {xy_}")
 
 
 async def test_prog2(context):

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -46,11 +46,10 @@ class PreProcessedElements(object):
             return [int(line) for line in lines]
 
     def _write_shares_to_file(self, f, degree, myid, shares):
-        print(self.field.modulus, file=f)
-        print(degree, file=f)
-        print(myid, file=f)
+        content = f"{self.field.modulus}\n{degree}\n{myid}\n"
         for share in shares:
-            print(share.value, file=f)
+            content += f"{share.value}\n"
+        f.write(content)
 
     def _write_polys(self, file_name_prefix, n, t, polys):
         for i in range(n):
@@ -92,8 +91,15 @@ class PreProcessedElements(object):
     def generate_powers(self, k, n, t, z):
         self._create_sharedata_dir_if_not_exists()
         b = randint(0, self.field.modulus-1)
+
+        # Since we need all powers, multiplication
+        # is faster than using the pow() function.
+        powers = [None] * k
+        powers[0] = b
+        for i in range(1, k):
+            powers[i] = powers[i-1] * b
         for i in range(z):
-            polys = [self.poly.random(t, pow(b, j)) for j in range(1, k+1)]
+            polys = [self.poly.random(t, power) for power in powers]
             self._write_polys(
                 f"{PreProcessingConstants.POWERS_FILE_NAME_PREFIX}_{i}", n, t, polys)
 


### PR DESCRIPTION
* Update AWS code to use the new json config.
* Add the `induce_faults` option to `aws-config.json` so the code can
actually be benchmarked in failure mode without rebuild/redeploy.
* Upload files/configs in parallel by default.
* Measure time taken to execute different operations within the AWS code
so when running the experiments later in case something is extremely
slow then that step can be optimized.
* Optimize the preprocessing code to not generate power in every
iteration instead generate the powers once. This reduces the time taken
to generate random powers to 0.33x.
* Replace all print statements with logging module. Since the logger logs
the current time, it also makes it helpful while running the experiments
to estimate how much time has elapsed.