### PR TITLE
Optimize preprocessing and fix AWS __init__.py

### DIFF
--- a/aws/__init__.py
+++ b/aws/__init__.py
@@ -1,8 +1,10 @@
 import logging.config
 import yaml
+import os
 
 
 with open('honeybadgermpc/logging.yaml', 'r') as f:
+    os.makedirs("benchmark", exist_ok=True)
     logging_config = yaml.safe_load(f.read())
     logging.config.dictConfig(logging_config)
     logging.getLogger('paramiko').setLevel(logging.WARNING)

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -6,6 +6,7 @@ from random import randint
 from os import makedirs
 from .field import GF
 from .polynomial import polynomials_over
+from .ntl.helpers import batch_vandermonde_evaluate
 from .elliptic_curve import Subgroup
 
 
@@ -52,8 +53,11 @@ class PreProcessedElements(object):
         f.write(content)
 
     def _write_polys(self, file_name_prefix, n, t, polys):
+        polys = [[coeff.value for coeff in poly.coeffs] for poly in polys]
+        all_shares = batch_vandermonde_evaluate(
+            list(range(1, n+1)), polys, self.field.modulus)
         for i in range(n):
-            shares = [f(i+1) for f in polys]
+            shares = [self.field(s[i]) for s in all_shares]
             with open('%s_%d_%d-%d.share' % (file_name_prefix, n, t, i), 'w') as f:
                 self._write_shares_to_file(f, t, i, shares)
 


### PR DESCRIPTION
**Add `benchmark` folder to aws/__init__.py**
This is needed to be able to load the logging config without any errors.

**Optimize evaluation of polynomials by using ntl**
Switch to vandermonde evaluate exposed via NTL for evaluating the
polynomial at a range of values. This would bring down the amount of
time required to create the preprocessing files.