### PR TITLE
 Add a way to benchmark existing code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ aws/aws-config.json
 
 *~
 sharedata/
+
+# Graphs
+*.svg

--- a/aws/__init__.py
+++ b/aws/__init__.py
@@ -4,7 +4,7 @@ import os
 
 
 with open('honeybadgermpc/logging.yaml', 'r') as f:
-    os.makedirs("benchmark", exist_ok=True)
+    os.makedirs("benchmark-logs", exist_ok=True)
     logging_config = yaml.safe_load(f.read())
     logging.config.dictConfig(logging_config)
     logging.getLogger('paramiko').setLevel(logging.WARNING)

--- a/aws/run-on-ec2.py
+++ b/aws/run-on-ec2.py
@@ -57,7 +57,7 @@ def run_commands_on_instances(
 def get_hbavss_setup_commands(s3manager, instance_ids):
     setup_commands = [[id, [
             "sudo docker pull %s" % (AwsConfig.DOCKER_IMAGE_PATH),
-            "mkdir -p benchmark",
+            "mkdir -p benchmark-logs",
         ]] for i, id in enumerate(instance_ids)]
     return setup_commands
 
@@ -82,7 +82,7 @@ def get_ipc_setup_commands(s3manager, instance_ids):
             "mkdir -p sharedata",
             "cd sharedata; curl -sSO %s" % (triple_urls[i]),
             "cd sharedata; curl -sSO %s" % (zero_urls[i]),
-            "mkdir -p benchmark",
+            "mkdir -p benchmark-logs",
         ]] for i, instance_id in enumerate(instance_ids)]
 
     return setup_commands
@@ -121,7 +121,7 @@ def get_butterfly_network_setup_commands(max_k, s3manager, instance_ids):
             "cd sharedata; curl -sSO %s" % (triple_urls[i]),
             "cd sharedata; curl -sSO %s" % (rand_share_urls[i]),
             "cd sharedata; curl -sSO %s" % (input_urls[i]),
-            "mkdir -p benchmark",
+            "mkdir -p benchmark-logs",
         ]] for i, instance_id in enumerate(instance_ids)]
 
     return setup_commands
@@ -150,7 +150,7 @@ def get_powermixing_setup_commands(max_k, runid, s3manager, instance_ids):
             f"curl -sSO {url}",
             "mkdir -p sharedata",
             "cp download_input.sh sharedata/download_input.sh ",
-            "mkdir -p benchmark",
+            "mkdir -p benchmark-logs",
             "ulimit -n 10000",
         ]
         file_names = []
@@ -244,17 +244,17 @@ def trigger_run(run_id, skip_setup, max_k, only_setup, cleanup):
                 -p {port}:{port} \
                 -v /home/ubuntu/config:/usr/src/HoneyBadgerMPC/config/ \
                 -v /home/ubuntu/sharedata:/usr/src/HoneyBadgerMPC/sharedata/ \
-                -v /home/ubuntu/benchmark:/usr/src/HoneyBadgerMPC/benchmark/ \
+                -v /home/ubuntu/benchmark-logs:/usr/src/HoneyBadgerMPC/benchmark-logs/ \
                 {AwsConfig.DOCKER_IMAGE_PATH} \
                 {AwsConfig.MPC_CONFIG.COMMAND} -d -f config/config-{i}.json"
             ]] for i, instance_id in enumerate(instance_ids)]
         logging.info("Triggering MPC commands.")
         run_commands_on_instances(ec2manager, instance_commands)
         logging.info("Collecting logs.")
-        log_collection_cmds = [[id, ["cat benchmark/*.log"]] for id in instance_ids]
+        log_collection_cmds = [[id, ["cat benchmark-logs/*.log"]] for id in instance_ids]
         os.makedirs(run_id, exist_ok=True)
         run_commands_on_instances(
-            ec2manager, log_collection_cmds, True, f"{run_id}/benchmark")
+            ec2manager, log_collection_cmds, True, f"{run_id}/benchmark-logs")
 
     s3manager.cleanup()
 

--- a/benchmark/test_benchmark_preprocessing.py
+++ b/benchmark/test_benchmark_preprocessing.py
@@ -1,0 +1,22 @@
+from pytest import mark
+from honeybadgermpc.preprocessing import PreProcessedElements
+
+
+@mark.parametrize("n,t,k", [
+    (4, 1, 1024),
+    (16, 5, 512),
+    (50, 15, 256),
+])
+def test_benchmark_generate_rands(benchmark, n, t, k):
+    pp_elements = PreProcessedElements()
+    benchmark(pp_elements.generate_rands, k, n, t)
+
+
+@mark.parametrize("n,t,k,z", [
+    (4, 1, 64, 64),
+    (16, 5, 32, 32),
+    (61, 20, 32, 32),
+])
+def test_benchmark_generate_powers(benchmark, n, t, k, z):
+    pp_elements = PreProcessedElements()
+    benchmark(pp_elements.generate_powers, k, n, t, z)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         BUILD: dev,aws
     volumes:
       - ./apps:/usr/src/HoneyBadgerMPC/apps
+      - ./benchmark:/usr/src/HoneyBadgerMPC/benchmark
       - ./aws:/usr/src/HoneyBadgerMPC/aws
       - ./conf:/usr/src/HoneyBadgerMPC/conf
       - ./docs:/usr/src/HoneyBadgerMPC/docs

--- a/honeybadgermpc/__init__.py
+++ b/honeybadgermpc/__init__.py
@@ -8,7 +8,7 @@ from honeybadgermpc.config import HbmpcConfig
 
 
 with open('honeybadgermpc/logging.yaml', 'r') as f:
-    os.makedirs("benchmark", exist_ok=True)
+    os.makedirs("benchmark-logs", exist_ok=True)
     logging_config = yaml.safe_load(f.read())
     logging.config.dictConfig(logging_config)
     logging.getLogger('asyncio').setLevel(logging.WARNING)

--- a/honeybadgermpc/logging.yaml
+++ b/honeybadgermpc/logging.yaml
@@ -11,7 +11,7 @@ handlers:
     stream: ext://sys.stdout
   logfile:
     class: logging.FileHandler
-    filename: benchmark/benchmark.log
+    filename: benchmark-logs/benchmark.log
     formatter: with_node_id
 loggers:
   benchmark_logger:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,9 @@
 log_level = DEBUG
 log_file = tests/.pytest.log
 log_file_level = DEBUG
-norecursedirs = charm
+# Skip `charm` tests since it slows down the CI
+# Skip benchmark since that is meant to be run locally only
+norecursedirs = charm benchmark
 
 # depends on pytest-env plugin ()
 env = 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ TESTS_REQUIRES = [
     'pytest-mock',
     'pytest-cov',
     'pytest-env',
+    'pytest-benchmark',
+    'pytest-benchmark[histogram]',
     'pyyaml',
 ]
 


### PR DESCRIPTION
* Added `pytest-benchmark` as a dependency, this allows writing test
cases which basically benchmark the code.
* The documentation can be read here: https://pytest-benchmark.readthedocs.io
* It spits out a report after running the tests which describes the
amount of time it took to benchmark a function.
* There is also an option to generate a histogram and compare with
previous results.

![image](https://user-images.githubusercontent.com/5889240/53705264-be8b0680-3de8-11e9-943a-94f50aff3063.png)

![image](https://user-images.githubusercontent.com/5889240/53705277-d5315d80-3de8-11e9-8570-8eea98c16687.png)
