### PR TITLE
Work with a specific commit of charm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 RUN ln -sf bash /bin/sh
 
 RUN git clone https://github.com/JHUISI/charm.git
-RUN cd charm && ./configure.sh && make install
+RUN cd charm && git reset --hard be9587ccdd4d61c591fb50728ebf2a4690a2064f && ./configure.sh && make install
 
 # This is needed otherwise the build for the power sum solver will fail.
 # This is a known issue in the version of libflint-dev in apt.


### PR DESCRIPTION
Current `charm` branch does not build. In order to get around that, we
can stick to a specific commit when things were OK. This commit is from
March 1.