### PR TITLE
Tweak HbAVSSLight & AVSSValueProcessor for offline

### DIFF
--- a/honeybadgermpc/batch_reconstruction.py
+++ b/honeybadgermpc/batch_reconstruction.py
@@ -42,6 +42,13 @@ def subscribe_recv(recv):
     return _task, subscribe
 
 
+def wrap_send(tag, send):
+    def _send(j, o):
+        send(j, (tag, o))
+
+    return _send
+
+
 def recv_each_party(recv, n):
     queues = [Queue() for _ in range(n)]
 

--- a/honeybadgermpc/hbavss_light.py
+++ b/honeybadgermpc/hbavss_light.py
@@ -1,6 +1,5 @@
 import logging
 import asyncio
-from collections import defaultdict
 from pickle import dumps, loads
 from honeybadgermpc.betterpairing import ZR
 from honeybadgermpc.polynomial import polynomials_over
@@ -9,11 +8,12 @@ from honeybadgermpc.symmetric_crypto import SymmetricCrypto
 from honeybadgermpc.exceptions import HoneyBadgerMPCError
 from honeybadgermpc.protocols.reliablebroadcast import reliablebroadcast
 
+# TODO: Move these to a separate file instead of using it from batch_reconstruction.py
+from honeybadgermpc.batch_reconstruction import subscribe_recv, wrap_send
+
 
 class HbAVSSMessageType:
     OK = "OK"
-    AVSS = "AVSS"
-    RBC = "RBC"
 
 
 class HbAvssLight(object):
@@ -23,57 +23,41 @@ class HbAvssLight(object):
         self.g = g
         self.poly_commit = PolyCommit(g, h)
 
-        # A different set of send, recv values must be passed for each AVSS object.
-        # If the same sends, recvs are reused then the recv_loops of the two objects
-        # can get values belonging to the other object.
-        self.send, self.recv = send, recv
+        # Create a mechanism to split the `recv` channels based on `tag`
+        self.subscribe_recv_task, self.subscribe_recv = subscribe_recv(recv)
+
+        # Create a mechanism to split the `send` channels based on `tag`
+        def _send(tag):
+            return wrap_send(tag, send)
+        self.get_send = _send
+
+        # This is added to consume the share the moment it is generated.
+        # This is especially helpful when running multiple AVSSes in parallel.
+        self.output_queue = asyncio.Queue()
 
         self.field = ZR
         self.poly = polynomials_over(self.field)
 
-        # When running multiple AVSSes, the messages are forwarded to the correct
-        # RBC/AVSS using these queues. The key is the AVSS ID which is sent along
-        # with each RBC/AVSS message.
-        self.rbc_queues = defaultdict(asyncio.Queue)
-        self.avss_queues = defaultdict(asyncio.Queue)
-
-        # This is used for generating the AVSS Id.
-        self.counter = 0
-
     def __enter__(self):
-        # Start the recv loop. This receives messages for all running AVSSes.
-        # It puts the messages intened for a specific AVSS in its queue based
-        # on the AVSS id.
-        self.recv_loop_task = asyncio.create_task(self._recv_loop())
         return self
 
     def __exit__(self, type, value, traceback):
-        self.recv_loop_task.cancel()
+        self.subscribe_recv_task.cancel()
 
-    async def _recv_loop(self):
-        while True:
-            sender_id, recvd_msg = await self.recv()
-            msg_type, avss_id = recvd_msg[0]
-            logging.debug("[%d] MsgType [%s] AvssId [%s]", self.my_id, msg_type, avss_id)
-            if msg_type == HbAVSSMessageType.RBC:
-                await self.rbc_queues[avss_id].put((sender_id, recvd_msg))
-            elif msg_type == HbAVSSMessageType.AVSS:
-                await self.avss_queues[avss_id].put((sender_id, recvd_msg))
-            else:
-                logging.error("Invalid message type [%s] received.", msg_type)
-                raise HoneyBadgerMPCError("Invalid message type received in recv_loop.")
+    async def _process_avss_msg(self, avss_id, dealer_id, avss_msg):
+        tag = f"{dealer_id}-{avss_id}-AVSS"
+        send, recv = self.get_send(tag), self.subscribe_recv(tag)
 
-    async def _process_avss_msg(self, avss_id, avss_msg, recv):
         def multicast(msg):
             for i in range(self.n):
-                self.send(i, msg)
+                send(i, msg)
 
         commitments, ephemeral_public_key, encrypted_witnesses = loads(avss_msg)
         shared_key = pow(ephemeral_public_key, self.private_key)
         share, witness = SymmetricCrypto.decrypt(
             str(shared_key).encode("utf-8"), encrypted_witnesses[self.my_id])
         if self.poly_commit.verify_eval(commitments, self.my_id+1, share, witness):
-            multicast(((HbAVSSMessageType.AVSS, avss_id), HbAVSSMessageType.OK))
+            multicast(HbAVSSMessageType.OK)
         else:
             logging.error("PolyCommit verification failed.")
             raise HoneyBadgerMPCError("PolyCommit verification failed.")
@@ -81,11 +65,15 @@ class HbAvssLight(object):
         oks_recvd = 0
         while oks_recvd < 2*self.t + 1:
             _, avss_msg = await recv()  # First value is the `sid`
-            if avss_msg[1] == HbAVSSMessageType.OK:
+            if avss_msg == HbAVSSMessageType.OK:
                 oks_recvd += 1
 
-        logging.debug("[%d][HbAVSSLight] 2t+1 OKs received.", self.my_id)
-        return share
+        # Output the share as an integer so it is not tied to a type like ZR/GFElement
+        share_int = int(share)
+        self.output_queue.put_nowait((dealer_id, avss_id, share_int))
+
+        logging.debug("[%d] 2t+1 OKs received.", self.my_id)
+        return share_int
 
     def _get_dealer_msg(self, value):
         phi = self.poly.random(self.t, value)
@@ -101,7 +89,34 @@ class HbAvssLight(object):
 
         return dumps((commitments, ephemeral_public_key, z))
 
-    async def avss(self, value=None, dealer_id=None, client_mode=False):
+    async def avss(self, avss_id, value=None, dealer_id=None, client_mode=False):
+        """
+        avss_id: This must be an integer. This must start from 0 per dealer. This is
+        important since it used to ensure an in order delivery of values at each node
+        per dealer i.e. if a node deals two values, then the shares of those values
+        need to be received in the order that they are dealt.
+
+        Eg:
+        => If there are 4 nodes and node 0 wants to deal two values:
+
+        node 0: avss(0, value=value1, dealer_id=0)
+        node 1: avss(0, dealer_id=0)
+        node 2: avss(0, dealer_id=0)
+        node 3: avss(0, dealer_id=0)
+
+        node 0: avss(1, value=value2, dealer_id=0)
+        node 1: avss(1, dealer_id=0)
+        node 2: avss(1, dealer_id=0)
+        node 3: avss(1, dealer_id=0)
+
+        => Now, if node 1 wants to deal a value next,
+        => the avss_id still must start from 0:
+
+        node 0: avss(0, value=value3, dealer_id=1)
+        node 1: avss(0, dealer_id=1)
+        node 2: avss(0, dealer_id=1)
+        node 3: avss(0, dealer_id=1)
+        """
         # If `value` is passed then the node is a 'Sender'
         # `dealer_id` must be equal to `self.my_id`
         if value is not None:
@@ -115,25 +130,26 @@ class HbAvssLight(object):
         if client_mode:
             assert dealer_id is not None
             assert dealer_id == self.n
+        assert type(avss_id) is int
 
-        # Choose the avss_id based on the order this is called
-        avss_id = f"AVSS-{self.counter}"
-        self.counter += 1
-        logging.debug("[%d] Starting AVSS [%s]", self.my_id, avss_id)
+        logging.debug("[%d] Starting AVSS. Id: %s, Dealer Id: %d, Client Mode: %s",
+                      self.my_id, avss_id, dealer_id, client_mode)
 
         broadcast_msg = None if self.my_id != dealer_id else self._get_dealer_msg(value)
         # In the client_mode, the dealer is the last node
         n = self.n if not client_mode else self.n+1
 
+        tag = f"{dealer_id}-{avss_id}-RBC"
+        send, recv = self.get_send(tag), self.subscribe_recv(tag)
         avss_msg = await reliablebroadcast(
-            (HbAVSSMessageType.RBC, avss_id),
+            tag,
             self.my_id,
             n,
             self.t,
             dealer_id,
             broadcast_msg,
-            self.rbc_queues[avss_id].get,
-            self.send
+            recv,
+            send
         )
 
         if client_mode and self.my_id == dealer_id:
@@ -141,17 +157,22 @@ class HbAvssLight(object):
             # anything after sending the initial value.
             return
 
-        logging.debug("[%d][HbAVSSLight] RBC completed.", self.my_id)
-        share = await self._process_avss_msg(
-            avss_id, avss_msg, self.avss_queues[avss_id].get)
-        logging.debug("[%d][HbAVSSLight] AVSS [%s] completed.", self.my_id, avss_id)
+        logging.debug("[%d] RBC completed.", self.my_id)
+        share = await self._process_avss_msg(avss_id, dealer_id, avss_msg)
+        logging.debug("[%d] AVSS [%s] completed.", self.my_id, avss_id)
         return share
 
-    async def avss_parallel(self, k, values=None, dealer_id=None):
+    async def avss_parallel(self, avss_id, k, values=None, dealer_id=None):
+        """
+        Run a HbAVSSLight in parallel for each of the values.
+
+        avss_id: This must be an integer. This must start from 0 per dealer.
+        Look at the `avss` method above for a detailed explanation.
+        """
         if values is not None:
             assert len(values) == k
         avss_tasks = [None]*k
         for i in range(k):
             v = None if values is None else values[i]
-            avss_tasks[i] = asyncio.create_task(self.avss(v, dealer_id))
+            avss_tasks[i] = asyncio.create_task(self.avss(k*avss_id+i, v, dealer_id))
         return await asyncio.gather(*avss_tasks)

--- a/honeybadgermpc/protocols/binaryagreement.py
+++ b/honeybadgermpc/protocols/binaryagreement.py
@@ -109,7 +109,8 @@ async def binaryagreement(sid, pid, n, f, coin, input_msg, decide, broadcast, re
                     est_sent[r][v] = True
                     broadcast(('EST', r, v))
                     logging.debug(
-                        f"[{pid}] broadcast {('EST', r, v)}", extra={'nodeid': pid, 'epoch': r})
+                        f"[{pid}] broadcast {('EST', r, v)}",
+                        extra={'nodeid': pid, 'epoch': r})
 
                 # Output after reaching second threshold
                 if len(est_values[r][v]) >= 2 * f + 1:
@@ -136,8 +137,8 @@ async def binaryagreement(sid, pid, n, f, coin, input_msg, decide, broadcast, re
                         'Redundant AUX received {}'.format(msg))
 
                 logging.debug(
-                    f'[{pid}] add sender = {sender} to aux_value[{r}][{v}] = {aux_values[r][v]}',
-                    extra={'nodeid': pid, 'epoch': r},
+                    f'[{pid}] add sender = {sender} to aux_value[{r}][{v}] = \
+                        {aux_values[r][v]}', extra={'nodeid': pid, 'epoch': r},
                 )
                 aux_values[r][v].add(sender)
                 logging.debug(
@@ -166,7 +167,8 @@ async def binaryagreement(sid, pid, n, f, coin, input_msg, decide, broadcast, re
     r = 0
     already_decided = None
     while True:  # Unbounded number of rounds
-        logging.info(f'[{pid}] Starting with est = {est}', extra={'nodeid': pid, 'epoch': r})
+        logging.info(f'[{pid}] Starting with est = {est}',
+                     extra={'nodeid': pid, 'epoch': r})
 
         if not est_sent[r][est]:
             est_sent[r][est] = True
@@ -178,7 +180,8 @@ async def binaryagreement(sid, pid, n, f, coin, input_msg, decide, broadcast, re
             await bv_signal.wait()
 
         w = next(iter(bin_values[r]))  # take an element
-        logging.debug(f"[{pid}] broadcast {('AUX', r, w)}", extra={'nodeid': pid, 'epoch': r})
+        logging.debug(f"[{pid}] broadcast {('AUX', r, w)}",
+                      extra={'nodeid': pid, 'epoch': r})
         broadcast(('AUX', r, w))
 
         values = None
@@ -187,9 +190,11 @@ async def binaryagreement(sid, pid, n, f, coin, input_msg, decide, broadcast, re
                       extra={'nodeid': pid, 'epoch': r})
         while True:
             logging.debug(
-                f'[{pid}] bin_values[{r}]: {bin_values[r]}', extra={'nodeid': pid, 'epoch': r})
+                f'[{pid}] bin_values[{r}]: {bin_values[r]}',
+                extra={'nodeid': pid, 'epoch': r})
             logging.debug(
-                f'[{pid}] aux_values[{r}]: {aux_values[r]}', extra={'nodeid': pid, 'epoch': r})
+                f'[{pid}] aux_values[{r}]: {aux_values[r]}',
+                extra={'nodeid': pid, 'epoch': r})
             # Block until at least N-f AUX values are received
             if 1 in bin_values[r] and len(aux_values[r][1]) >= n - f:
                 values = set((1,))
@@ -212,8 +217,8 @@ async def binaryagreement(sid, pid, n, f, coin, input_msg, decide, broadcast, re
 
         # CONF phase
         logging.debug(
-                      f'[{pid}] block until at least N-f ({n-f}) CONF values are received',
-                      extra={'nodeid': pid, 'epoch': r})
+                      f'[{pid}] block until at least N-f ({n-f}) CONF values\
+                    are received', extra={'nodeid': pid, 'epoch': r})
         if not conf_sent[r][tuple(values)]:
             values = await wait_for_conf_values(
                 pid=pid,

--- a/honeybadgermpc/protocols/commoncoin.py
+++ b/honeybadgermpc/protocols/commoncoin.py
@@ -76,7 +76,8 @@ async def shared_coin(sid, pid, n, f, pk, sk, broadcast, receive):
                 # Compute the bit from the least bit of the hash
                 bit = hash(serialize(sig))[0] % 2
                 logging.debug(
-                    f'[{pid}] put bit {bit} in output queue', extra={'nodeid': pid, 'epoch': r})
+                    f'[{pid}] put bit {bit} in output queue',
+                    extra={'nodeid': pid, 'epoch': r})
                 output_queue[r].put_nowait(bit)
 
     recv_task = asyncio.create_task(_recv())

--- a/honeybadgermpc/protocols/crypto/boldyreva.py
+++ b/honeybadgermpc/protocols/crypto/boldyreva.py
@@ -173,7 +173,10 @@ class TBLSPrivateKey(TBLSPublicKey):
 def dealer(players=10, k=5, seed=None):
     """ """
     # Random polynomial coefficients
-    a = group.random(ZR, count=k, seed=seed)
+    if seed is not None:
+        a = [group.random(ZR, seed=seed+i) for i in range(k)]
+    else:
+        a = group.random(ZR, count=k)
     assert len(a) == k
     secret = a[0]
 

--- a/honeybadgermpc/protocols/reliablebroadcast.py
+++ b/honeybadgermpc/protocols/reliablebroadcast.py
@@ -185,7 +185,7 @@ async def reliablebroadcast(sid, pid, n, f, leader, input, receive, send):
         # strings
         # (with Python 2 it used to be: assert type(m) is str)
         assert isinstance(m, (str, bytes))
-        logging.debug('Input received: %d bytes' % (len(m),))
+        logging.debug('[%d] Input received: %d bytes' % (pid, len(m),))
 
         stripes = encode(k, n, m)
         mt = merkle_tree(stripes)  # full binary tree
@@ -221,12 +221,12 @@ async def reliablebroadcast(sid, pid, n, f, leader, input, receive, send):
             # Validation
             (_, _, roothash, branch, stripe) = msg
             if sender != leader:
-                logging.info(f"VAL message from other than leader: {sender}")
+                logging.info(f"[{pid}] VAL message from other than leader: {sender}")
                 continue
             try:
                 assert merkle_verify(n, stripe, roothash, branch, pid)
             except Exception as e:
-                logging.info(f"Failed to validate VAL message: {e}")
+                logging.info(f"[{pid}]Failed to validate VAL message: {e}")
                 continue
 
             # Update
@@ -238,7 +238,7 @@ async def reliablebroadcast(sid, pid, n, f, leader, input, receive, send):
             # Validation
             if roothash in stripes and stripes[roothash][sender] is not None \
                or sender in echo_senders:
-                logging.info("Redundant ECHO")
+                logging.info("[{pid}] Redundant ECHO")
                 continue
 
             # We can optimistically skip the merkleVerify for "ECHO", because the
@@ -266,7 +266,7 @@ async def reliablebroadcast(sid, pid, n, f, leader, input, receive, send):
             (_, _, roothash) = msg
             # Validation
             if sender in ready[roothash] or sender in ready_senders:
-                logging.info("Redundant READY")
+                logging.info("[{pid}] Redundant READY")
                 continue
 
             # Update

--- a/honeybadgermpc/sequencer.py
+++ b/honeybadgermpc/sequencer.py
@@ -1,0 +1,47 @@
+import heapq
+
+
+class Sequencer(object):
+    """
+    It's an abstract data structure implemented just on top of a priority queue. It
+    holds items of the form (i, _, ..). Items can be enqueued in any order, but `get`
+    will always return them in strict counting order, (1, _),(2, _),... so values
+    added out of order are buffered until the next counting number is available.
+    """
+    def __init__(self):
+        self.heap = []
+        self.values = set()  # Use this to ensure a duplicate is not added
+        self.next = 0
+
+    def get(self):
+        """
+        Returns the next value as per the counting order.
+
+        If the next value is not available then this method throws an error. Therefore,
+        `is_next_available` should be called before calling `get` to see if the next
+        value is available or not.
+        """
+        assert self.is_next_available()
+        value = heapq.heappop(self.heap)
+        self.values.remove(value[0])
+        self.next += 1
+        return value
+
+    def is_next_available(self):
+        """
+        Returns if the next value in the counting order is available or not.
+        """
+        return len(self.heap) > 0 and self.heap[0][0] == self.next
+
+    def add(self, value):
+        """
+        Adds a value to the sequencer.
+
+        value: a `tuple` or a `list` with at least two elements where the first element
+        denotes the sequence number.
+        """
+        assert type(value) in [tuple, list]
+        assert type(value[0]) is int
+        assert value[0] not in self.values
+        self.values.add(value[0])
+        heapq.heappush(self.heap, value)

--- a/tests/test_avss_value_processor.py
+++ b/tests/test_avss_value_processor.py
@@ -12,10 +12,10 @@ async def test_avss_value_processor_with_diff_inputs(test_router):
     sends, recvs, _ = test_router(n)
 
     node_inputs = [
-        [(0, "00"), (1, "10"), (2, "20")],
-        [(0, "01")],
-        [(0, "02"), (2, "22")],
-        [(3, "33")]
+        [(0, 0, "00"), (1, 0, "10"), (2, 0, "20")],
+        [(0, 0, "01")],
+        [(0, 0, "02"), (2, 0, "22")],
+        [(3, 0, "33")]
     ]
 
     get_tasks = [None]*n
@@ -248,7 +248,7 @@ async def test_with_agreed_values_on_same_node_with_input(k, acs_outputs):
     with AvssValueProcessor(None, None, n, t, my_id,
                             None, None, input_q.get) as proc:
         for i in range(k):
-            value = (my_id, i)  # dealer_id, value
+            value = (my_id, i, i)  # dealer_id, avss_id, value
             input_q.put_nowait(value)
         await asyncio.sleep(0.1)  # Give the recv loop a chance to run
         proc._process_acs_output(acs_outputs)
@@ -304,7 +304,7 @@ async def test_with_agreed_values_on_another_node_with_input(k, acs_outputs):
         assert all(proc.next_idx_to_return_per_dealer[i] == 0 for i in range(n))
 
         for i in range(k):
-            value = (sender_id, i)  # dealer_id, avss_value
+            value = (sender_id, i, i)  # dealer_id, avss_id, value
             input_q.put_nowait(value)  # Make the 0th node receive the value now
 
         await asyncio.sleep(0.1)  # Give the recv loop a chance to run

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,0 +1,69 @@
+from pytest import mark, raises
+from random import shuffle, randint
+from honeybadgermpc.sequencer import Sequencer
+
+
+@mark.parametrize("input_values", (
+    (
+        [(2, "v"), (3, "v"), (1, "v"), (0, "v"), (4, "v")],
+        [(0, "v"), (1, "v"), (2, "v"), (3, "v"), (4, "v")],
+        [(4, "v"), (3, "v"), (2, "v"), (1, "v"), (0, "v")],
+        [(5, "v"), (6, "v"), (1, "v"), (2, "v"), (3, "v"), (4, "v"), (0, "v")]
+    )
+))
+def test_fixed(input_values):
+    output_values = sorted(input_values, key=lambda x: x[0])
+    sequencer = Sequencer()
+    for value in input_values:
+        sequencer.add(value)
+    for value in output_values:
+        assert sequencer.is_next_available()
+        assert value == sequencer.get()
+    assert not sequencer.is_next_available()  # All retrieved, should return false
+
+
+def test_random():
+    n = randint(10, 50)
+    output_values = [(i, "v") for i in range(n)]
+    input_values = output_values[::]
+    shuffle(input_values)
+    sequencer = Sequencer()
+    for value in input_values:
+        sequencer.add(value)
+    for value in output_values:
+        assert sequencer.is_next_available()
+        assert value == sequencer.get()  # All retrieved, should return false
+
+
+def test_already_existing_fail():
+    with raises(AssertionError):
+        sequencer = Sequencer()
+        sequencer.add((0, "v"))
+        sequencer.add((0, "v"))
+
+
+def test_already_existing_pass():
+    sequencer = Sequencer()
+    sequencer.add((0, "v"))
+    assert sequencer.get() == (0, "v")
+    sequencer.add((0, "v"))  # should pass
+
+
+def test_add_get_add():
+    sequencer = Sequencer()
+    sequencer.add((0, "v"))
+    assert sequencer.get() == (0, "v")
+    sequencer.add((1, "v"))  # should pass
+    assert sequencer.is_next_available()
+    assert sequencer.get() == (1, "v")
+
+
+def test_missing():
+    sequencer = Sequencer()
+    sequencer.add((1, "v"))
+    assert not sequencer.is_next_available()
+
+
+def test_empty():
+    sequencer = Sequencer()
+    assert not sequencer.is_next_available()


### PR DESCRIPTION
**Tweak HbAVSSLight & AVSSValueProcessor for offline**

_* HbAVSSLight:_
* Add a notion of avss_id used to sequence the AVSSes per dealer.
* Switch to splitting send/recv channels for RBC and AVSS instead of
having one receive loop and introducing new message types.
* Add an output queue to which the share is added the moment it receives
enough acks.
* Update documentation to be clearer.
* Update tests to reflect the changes.

_* AVSSValueProcessor:_
* Run ACS periodically instead of having to run on demand.
* Add code to sequence the AVSS values per dealer based on the AVSS Id.
* Update tests to reflect the change.

_* Sequencer:_
* Added a sequencer module which exposes an interface to sequence values
from 0.
* Added tests for the same.

**Add node_id to logs generated in protocol/**