### PR TITLE
Create Progs folder for example MPC applications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         BUILD: dev,aws
     volumes:
       - ./apps:/usr/src/HoneyBadgerMPC/apps
+      - ./progs:/usr/src/HoneyBadgerMPC/progs
       - ./benchmark:/usr/src/HoneyBadgerMPC/benchmark
       - ./aws:/usr/src/HoneyBadgerMPC/aws
       - ./conf:/usr/src/HoneyBadgerMPC/conf

--- a/progs/triple_refinement.py
+++ b/progs/triple_refinement.py
@@ -1,4 +1,4 @@
-from .polynomial import get_omega
+from honeybadgermpc.polynomial import get_omega
 import asyncio
 import itertools
 

--- a/tests/progs/conftest.py
+++ b/tests/progs/conftest.py
@@ -1,0 +1,1 @@
+from tests.fixtures import *  # noqa: F403 F401

--- a/tests/progs/test_triple_refinement.py
+++ b/tests/progs/test_triple_refinement.py
@@ -5,7 +5,7 @@ import asyncio
 @mark.asyncio
 async def test_triple_refinement(test_preprocessing):
     from honeybadgermpc.mpc import TaskProgramRunner
-    from honeybadgermpc.triple_refinement import refine_triples
+    from progs.triple_refinement import refine_triples
 
     n, t = 7, 2
 


### PR DESCRIPTION
This PR creates a `prog` folder for storing example MPC applications, and starts by moving the existing `triple_refinement.py` to `prog/triple_refinement.py`