### PR TITLE
Parallelize test running

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,11 @@
 log_level = DEBUG
 log_file = tests/.pytest.log
 log_file_level = DEBUG
+
+# Sets the parallelism of running the test suite to use the 
+# number of cores of your processor (x2 if you have hyperthreading)
+addopts = -nauto
+
 # Skip `charm` tests since it slows down the CI
 # Skip benchmark since that is meant to be run locally only
 norecursedirs = charm benchmark

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ TESTS_REQUIRES = [
     'pytest-mock',
     'pytest-cov',
     'pytest-env',
+    'pytest-sugar',
+    'pytest-xdist',
     'pytest-benchmark',
     'pytest-benchmark[histogram]',
     'pyyaml',


### PR DESCRIPTION
This PR does 2 things:
- Installs `pytest-xdist` and `pytest-sugar` in the docker image (requires running `docker-compose build honeybadgermpc`)
- Sets the tests to run with how many cpu "cores" your system has (i.e. 4 core + hyperthreading => 8 worker threads) as the parallelism factor.

On my system, this cut out about a minute of test runtime.