### PR TITLE
Refactors GF to truly use the singleton pattern

### DIFF
--- a/apps/shuffle/powermixing.py
+++ b/apps/shuffle/powermixing.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
     try:
         if not HbmpcConfig.skip_preprocessing:
             # Need to keep these fixed when running on processes.
-            field = GF.get(Subgroup.BLS12_381)
+            field = GF(Subgroup.BLS12_381)
             a_s = [field(i) for i in range(1000+k, 1000, -1)]
 
             pp_elements = PreProcessedElements()

--- a/honeybadgermpc/batch_reconstruction.py
+++ b/honeybadgermpc/batch_reconstruction.py
@@ -124,7 +124,7 @@ async def batch_reconstruct(secret_shares, p, t, n, myid, send, recv, config=Non
     Reconstruction takes places in chunks of t+1 values
     """
 
-    fp = GF.get(p)
+    fp = GF(p)
     secret_shares = [v.value for v in secret_shares]
     round1_chunks = to_chunks(secret_shares, t + 1)
     num_chunks = len(round1_chunks)

--- a/honeybadgermpc/mpc.py
+++ b/honeybadgermpc/mpc.py
@@ -34,7 +34,7 @@ class Mpc(object):
         self.t = t
         self.myid = myid
         self.pid = pid
-        self.field = GF.get(Subgroup.BLS12_381)
+        self.field = GF(Subgroup.BLS12_381)
         self.poly = polynomials_over(self.field)
         self.config = config
 

--- a/honeybadgermpc/offline.py
+++ b/honeybadgermpc/offline.py
@@ -125,7 +125,7 @@ class RandomGenerator(PreProcessingBase):
     def __init__(self, n, t, my_id, send, recv, batch_size=10):
         super(RandomGenerator, self).__init__(
             n, t, my_id, send, recv, "rand", batch_size)
-        self.field = GF.get(Subgroup.BLS12_381)
+        self.field = GF(Subgroup.BLS12_381)
 
     def _get_input_batch(self):
         return [self.field.random().value for _ in range(self.batch_size)]
@@ -154,7 +154,7 @@ class TripleGenerator(PreProcessingBase):
         super(TripleGenerator, self).__init__(n, t, my_id, send, recv, "triple",
                                               batch_size,
                                               avss_value_processor_chunk_size=3)
-        self.field = GF.get(Subgroup.BLS12_381)
+        self.field = GF(Subgroup.BLS12_381)
 
     def _get_input_batch(self):
         inputs = []

--- a/honeybadgermpc/polynomial.py
+++ b/honeybadgermpc/polynomial.py
@@ -355,6 +355,7 @@ class EvalPoint(object):
     Without FFT:
     i'th point (zero-indexed) = i + 1
     """
+
     def __init__(self, field, n, use_fft=False):
         self.use_fft = use_fft
         self.field = field
@@ -384,7 +385,7 @@ class EvalPoint(object):
 
 
 if __name__ == "__main__":
-    field = GF.get(Subgroup.BLS12_381)
+    field = GF(Subgroup.BLS12_381)
     Poly = polynomials_over(field)
     poly = Poly.random(degree=7)
     poly = Poly([1, 5, 3, 15, 0, 3])

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -24,7 +24,7 @@ class PreProcessingConstants(object):
 
 class PreProcessedElements(object):
     def __init__(self):
-        self.field = GF.get(Subgroup.BLS12_381)
+        self.field = GF(Subgroup.BLS12_381)
         self.poly = polynomials_over(self.field)
         self._triples = {}
         self._zeros = {}

--- a/honeybadgermpc/rand_batch.py
+++ b/honeybadgermpc/rand_batch.py
@@ -5,7 +5,7 @@ from .polynomial import polynomials_over, get_omega
 from .elliptic_curve import Subgroup
 
 # Fix the field for now
-Field = GF.get(Subgroup.BLS12_381)
+Field = GF(Subgroup.BLS12_381)
 Poly = polynomials_over(Field)
 
 #######################################

--- a/honeybadgermpc/secretshare_functionality.py
+++ b/honeybadgermpc/secretshare_functionality.py
@@ -19,7 +19,7 @@ singleton Functionality.
 """
 
 # Fix the field for now
-Field = GF.get(Subgroup.BLS12_381)
+Field = GF(Subgroup.BLS12_381)
 Poly = polynomials_over(Field)
 
 

--- a/honeybadgermpc/wb_interpolate.py
+++ b/honeybadgermpc/wb_interpolate.py
@@ -54,7 +54,7 @@ def make_wb_encoder_decoder(n, k, p, point=None):
         raise Exception(
             "Must have k <= n <= p but instead had (n,k,p) == (%r, %r, %r)" % (n, k, p))
     t = k - 1  # degree of polynomial
-    fp = GF.get(p)
+    fp = GF(p)
     poly = polynomials_over(fp)
 
     # the message points correspond to polynomial evaluations
@@ -88,14 +88,14 @@ def make_wb_encoder_decoder(n, k, p, point=None):
 
             def row(i, a, b):
                 return (
-                        [b * a ** j for j in range(e_num_vars)] +
-                        [-1 * a ** j for j in range(q_num_vars)] + [0]
+                    [b * a ** j for j in range(e_num_vars)] +
+                    [-1 * a ** j for j in range(q_num_vars)] + [0]
                 )  # the "extended" part of the linear system
 
             system = (
-                    [row(i, a, b) for (i, (a, b)) in enumerate(encoded_message)] +
-                    [[fp(0)] * (e_num_vars - 1) + [fp(1)] + [fp(0)] * (q_num_vars) + [
-                        fp(1)]]
+                [row(i, a, b) for (i, (a, b)) in enumerate(encoded_message)] +
+                [[fp(0)] * (e_num_vars - 1) + [fp(1)] + [fp(0)] * (q_num_vars) + [
+                    fp(1)]]
             )  # ensure coefficient of x^e in E(x) is 1
 
             if debug:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,7 +7,7 @@ from pytest import fixture
 def galois_field():
     from honeybadgermpc.field import GF
     from honeybadgermpc.elliptic_curve import Subgroup
-    return GF.get(Subgroup.BLS12_381)
+    return GF(Subgroup.BLS12_381)
 
 
 @fixture

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,19 +1,18 @@
 import pytest
 import operator
 from pytest import raises
+from honeybadgermpc.field import GF, FieldsNotIdentical
 
 
 def test_multiple_fields():
-    from honeybadgermpc.field import GF
-    field1 = GF.get(17)
-    field2 = GF.get(7)
+    field1 = GF(17)
+    field2 = GF(7)
     assert field1.modulus == 17
     assert field2.modulus == 7
 
 
 def test_invalid_operations_on_fields():
-    from honeybadgermpc.field import GF, FieldsNotIdentical
-    field1, field2 = GF.get(17), GF.get(7)
+    field1, field2 = GF(17), GF(7)
     operators = [
         operator.add,
         operator.sub,
@@ -30,7 +29,7 @@ def test_invalid_operations_on_fields():
 
 def test_sqrt(galois_field):
     field = galois_field
-    for i in range(100):
+    for _ in range(100):
         num = galois_field.random()
         if pow(num, (field.modulus-1)//2) == 1:
             root = num.sqrt()
@@ -38,3 +37,13 @@ def test_sqrt(galois_field):
         else:
             with raises(AssertionError):
                 root = num.sqrt()
+
+
+def test_singleton_pattern():
+    gf_1 = GF(19)
+    gf_2 = GF(19)
+    assert gf_1 is gf_2
+    assert gf_1.modulus == 19
+    assert gf_2.modulus == 19
+    assert gf_1 is GF(19)
+    assert GF(19).modulus == 19


### PR DESCRIPTION
Currently, this is the state of `GF`:

```
g1 = GF(1)
g2 = GF(1)
assert g1 is g2 # fails assertion, they're different objects

g3 = GF.get(1)
g4 = GF.get(1)
assert g3 is g4 # passes assertion, intended functionality
```

This PR changes the way that we create `GF` objects, such that both assertions will pass and you can use either method of construction `GF` objects.

For more details, see #226 