### PR TITLE
Implement Jubjub MPC application

### DIFF
--- a/honeybadgermpc/elliptic_curve.py
+++ b/honeybadgermpc/elliptic_curve.py
@@ -1,2 +1,187 @@
+from .field import GF, GFElement
+
+
 class Subgroup:
     BLS12_381 = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+
+
+class Jubjub(object):
+    """
+    JubJub is a twisted Edwards curve of the form -x^2 + y^2 = 1 + dx^2y^2
+    """
+    Field = GF(Subgroup.BLS12_381)
+
+    def __init__(self, a: GFElement = Field(-1),
+                 d: GFElement = -(Field(10240)/Field(10241))):
+        self.a = a
+        self.d = d
+
+        a_d_diff = self.a - self.d
+        self.disc = self.a * self.d * a_d_diff * a_d_diff * a_d_diff * a_d_diff
+
+        if not self.is_smooth():
+            raise Exception(f"The curve {self} is not smooth!")
+
+    def __str__(self) -> str:
+        return '%sx^2 + y^2 = 1 + %sx^2y^2' % (self.a, self.d)
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __eq__(self, other) -> bool:
+        return (self.a, self.d) == (other.a, other.d)
+
+    def is_smooth(self) -> bool:
+        return self.disc != 0
+
+    def contains_point(self, p: 'Point') -> bool:
+        """
+        Checks whether or not the given point sits on the curve
+        """
+        return self.a * p.x * p.x + p.y * p.y == 1 + self.d * p.x * p.x * p.y * p.y
+
+
+class Point(object):
+    """
+    Represents a point with optimized operations over Edwards curves
+    This is the 'local' version of this class, that doesn't deal with shares
+    """
+
+    def __init__(self, x: int, y: int, curve: Jubjub = Jubjub()):
+        if not isinstance(curve, Jubjub):
+            raise Exception(
+                f"Could not create Point-- given curve \
+                not of type Jubjub ({type(curve)})")
+
+        self.curve = curve  # the curve containing this point
+        self.x = x
+        self.y = y
+
+        if not self.curve.contains_point(self):
+            raise Exception(
+                f"Could not create Point({self})-- not on the given curve {curve}!")
+
+    def __str__(self):
+        return "(%r, %r)" % (self.x, self.y)
+
+    def __repr__(self):
+        return str(self)
+
+    def __neg__(self):
+        return Point(self.curve.Field(-self.x), self.y, self.curve)
+
+    def __add__(self, other: 'Point') -> 'Point':
+        if self.curve != other.curve:
+            raise Exception("Can't add points on different curves!")
+
+        if isinstance(other, Ideal):
+            return self
+
+        x1, y1, x2, y2 = self.x, self.y, other.x, other.y
+
+        x3 = ((x1 * y2) + (y1 * x2)) / (1 + self.curve.d * x1 * x2 * y1 * y2)
+        y3 = ((y1 * y2) + (x1 * x2)) / (1 - self.curve.d * x1 * x2 * y1 * y2)
+
+        return Point(x3, y3)
+
+    def __sub__(self, other: 'Point') -> 'Point':
+        return self + -other
+
+    def __mul__(self, n: int) -> 'Point':
+        if not isinstance(n, int):
+            raise Exception("Can't scale a point by something which isn't an int!")
+
+        if n < 0:
+            return -self * -n
+        elif n == 0:
+            return Ideal(self.curve)
+
+        current = self
+        product = Point(0, 1, self.curve)
+
+        i = 1
+        while i <= n:
+            if n & i == i:
+                product += current
+
+            current += current
+            i <<= 1
+
+        return product
+
+    def __rmul__(self, n: int):
+        return self * n
+
+    def __list__(self):
+        return [self.x, self.y]
+
+    def __eq__(self, other: object) -> bool:
+        if type(other) is Ideal:
+            return False
+
+        return (self.x, self.y) == (other.x, other.y)
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+    def __getitem__(self, index: int) -> int:
+        return [self.x, self.y][index]
+
+    def double(self) -> 'Point':
+        return self + self
+
+
+class Ideal(Point):
+    """
+    Represents the point at infinity of the curve
+    """
+
+    def __init__(self, curve):
+        self.curve = curve
+
+    def __neg__(self):
+        return self
+
+    def __str__(self):
+        return "Ideal"
+
+    def __add__(self, other: 'Point') -> 'Point':
+        if not isinstance(other, Point):
+            raise Exception("Can't add something that's not a point to a point")
+        elif self.curve != other.curve:
+            raise Exception("Can't add points on different curves!")
+
+        return other
+
+    def __mul__(self, n: int) -> 'Point':
+        if not isinstance(n, int):
+            raise Exception("Can't scale a point by something which isn't an int!")
+
+        return self
+
+    def __eq__(self, other: object) -> bool:
+        return type(other) is Ideal
+
+
+if __name__ == '__main__':
+    """
+    main method for quick testing
+    """
+    n, t = 9, 2
+    curve = Jubjub()
+
+    p_actual = Point(0, 1)
+    x_secret, y_secret = p_actual.x, p_actual.y
+
+    p = Point(0, 1)
+    print(p)
+    ideal = Ideal(p.curve)
+    print(ideal)
+
+    print(p + ideal)
+    print(2 * p + 3 * ideal)
+
+    try:
+        print(p * ideal)
+    except Exception:
+        print('correctly prevented multiplying points')

--- a/progs/jubjub.py
+++ b/progs/jubjub.py
@@ -1,0 +1,228 @@
+from honeybadgermpc.elliptic_curve import Jubjub, Point
+from honeybadgermpc.mpc import Mpc
+
+
+class SharedPoint(object):
+    """
+    Represents a point with optimized operatons over Edward's curves.
+    This is the 'shared' version of this class, which does deal with shares
+    Math operations derived from
+    https://en.wikipedia.org/wiki/Twisted_Edwards_curve#Addition_on_twisted_Edwards_curves # noqa: E501
+    """
+
+    def __init__(self, context: Mpc, xs, ys, curve: Jubjub = Jubjub()):
+        if not isinstance(curve, Jubjub):
+            raise Exception(
+                f"Could not create Point-- given \
+                curve not of type Jubjub({type(curve)})")
+
+        self.context = context
+        self.curve = curve
+        self.xs = xs
+        self.ys = ys
+
+    async def __on_curve(self) -> bool:
+        """
+        Checks whether or not the given shares for x and y correspond to a
+        point that sits on the current curve
+
+        WARNING: This method currently leaks information about the shared point--
+                 We need to use share equality testing instead
+        """
+        x_sq = await(self.xs * self.xs)
+        y_sq = await(self.ys * self.ys)
+        a_ = self.context.Share(self.curve.a)
+        d_ = self.context.Share(self.curve.d)
+
+        # ax^2 + y^2
+        lhs = await(a_ * x_sq) + y_sq
+
+        # 1 + dx^2y^2
+        rhs = self.context.Share(1) + await(d_ * await(x_sq * y_sq))
+
+        # TODO: use share equality to prevent the leaking of data
+        return await lhs.open() == await rhs.open()
+
+    async def __init(self):
+        """asynchronous part of initialization via create or from_point
+        """
+        if not await(self.__on_curve()):
+            raise Exception(
+                f"Could not initialize Point {self}-- \
+                does not sit on given curve {self.curve}")
+
+    @staticmethod
+    async def create(context: Mpc, xs, ys, curve=Jubjub()):
+        """ Given a context, secret shared coordinates and a curve,
+            creates the given point
+        """
+        point = SharedPoint(context, xs, ys, curve)
+        await point.__init()
+
+        return point
+
+    @staticmethod
+    async def from_point(context: Mpc, p: Point) -> 'SharedPoint':
+        """ Given a local point and a context, created a shared point
+        """
+        if not isinstance(p, Point):
+            raise Exception(f"Could not create shared point-- p ({p}) is not a Point!")
+
+        return await(SharedPoint.create(context, context.Share(p.x), context.Share(p.y)))
+
+    def __str__(self) -> str:
+        return f"({self.xs}, {self.ys})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    async def neg(self):
+        return await(SharedPoint.create(self.context,
+                                        await(self.context.Share(-1) * self.xs),
+                                        self.ys,
+                                        self.curve))
+
+    async def add(self, other: 'SharedPoint') -> 'SharedPoint':
+        if isinstance(other, SharedIdeal):
+            return self
+        elif not isinstance(other, SharedPoint):
+            raise Exception(
+                "Could not add other point-- not an instance of SharedPoint")
+        elif self.curve != other.curve:
+            raise Exception("Can't add points on different curves!")
+        elif self.context != other.context:
+            raise Exception("Can't add points from different contexts!")
+
+        x1, y1, x2, y2 = self.xs, self.ys, other.xs, other.ys
+
+        one = self.context.Share(1)
+        y_prod = await(y1 * y2)
+        x_prod = await(x1 * x2)
+        d_ = self.context.Share(self.curve.d)
+
+        # d_prod = d*x1*x2*y1*y2
+        d_prod = await(await(d_ * x_prod) * y_prod)
+
+        # x3 = ((x1*y2) + (y1*x2)) / (1 + d*x1*x2*y1*y2)
+        x3 = await((await(x1 * y2) + await(y1 * x2)) / (one + d_prod))
+
+        # y3 = ((y1*y2) + (x1*x2)) / (1 - d*x1*x2*y1*y2)
+        y3 = await((y_prod + x_prod) / (one - d_prod))
+
+        return await(SharedPoint.create(self.context, x3, y3, self.curve))
+
+    async def sub(self, other: 'SharedPoint') -> 'SharedPoint':
+        return await self.add(await(other.neg()))
+
+    async def mul(self, n: int) -> 'SharedPoint':
+        # Using the Double-and-Add algorithm
+        # https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication
+        if not isinstance(n, int):
+            raise Exception("Can't scale a SharedPoint by something which isn't an int!")
+
+        if n < 0:
+            negated = await self.neg()
+            return await negated.mul(-n)
+        elif n == 0:
+            return SharedIdeal(self.curve)
+
+        current = self
+        product = await(SharedPoint.from_point(self.context, Point(0, 1, self.curve)))
+
+        i = 1
+        while i <= n:
+            if n & i == i:
+                product = await(product.add(current))
+
+            current = await(current.double())
+            i <<= 1
+
+        return product
+
+    async def montgomery_mul(self, n: int) -> 'SharedPoint':
+        # Using the Montgomery Ladder algorithm
+        # https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication
+        if not isinstance(n, int):
+            raise Exception("Can't scale a SharedPoint by something which isn't an int!")
+
+        if n < 0:
+            negated = await self.neg()
+            return await negated.mul(-n)
+        elif n == 0:
+            return SharedIdeal(self.curve)
+
+        current = self
+        product = await(SharedPoint.from_point(self.context, Point(0, 1, self.curve)))
+
+        i = 1 << n.bit_length()
+        while i > 0:
+            if n & i == i:
+                product = await product.add(current)
+                current = await current.double()
+            else:
+                current = await product.add(current)
+                product = await product.double()
+
+            i >>= 1
+
+        return product
+
+    async def double(self) -> 'SharedPoint':
+        # Uses the optimized implementation from wikipedia
+        x, y = self.xs, self.ys
+
+        x_sq, y_sq = await(x*x), await(y*y)
+        ax_sq = self.curve.a * x_sq
+
+        x_prod = 2 * await(x * y)
+        y_prod = y_sq - ax_sq
+
+        x_denom = ax_sq + y_sq
+        y_denom = self.context.Share(2) - ax_sq - y_sq
+
+        return await(SharedPoint.create(self.context,
+                                        await(x_prod / x_denom),
+                                        await(y_prod / y_denom),
+                                        self.curve))
+
+
+class SharedIdeal(SharedPoint):
+    """ Analogue of the Ideal class for shared points
+        Represents the point at infinity
+    """
+
+    def __init__(self, curve):
+        self.curve = curve
+
+    def __str__(self):
+        return "SharedIdeal"
+
+    async def neg(self):
+        return self
+
+    async def add(self, other):
+        if not isinstance(other, SharedPoint):
+            raise Exception(
+                "Can't add a shared point with something which isn't a shared point")
+        elif self.curve != other.curve:
+            raise Exception("Can't add points on different curves")
+
+        return self
+
+    async def sub(self, other):
+        if not isinstance(other, SharedPoint):
+            raise Exception(
+                "Can't subtract a shared point by something which isn't a shared point")
+        elif self.curve != other.curve:
+            raise Exception("Can't add points on different curves")
+
+        return self
+
+    async def mul(self, n):
+        if not isinstance(n, int):
+            raise Exception("Can't scale a point by something which isn't an int!")
+
+        return self
+
+    async def double(self):
+        return self

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -1,0 +1,193 @@
+from pytest import mark, raises
+from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.mixins import MixinOpName, BeaverTriple, Inverter
+from honeybadgermpc.elliptic_curve import Ideal, Point, Jubjub
+from progs.jubjub import SharedPoint, SharedIdeal
+
+TEST_CURVE = Jubjub()
+
+TEST_POINTS = [
+    Point(0, 1, TEST_CURVE),
+    Point(5, 6846412461894745224441235558443359243034138132682534265960483512729196124138, TEST_CURVE),  # noqa: E501
+    Point(10, 9069365299349881324022309154395348339753339814197599672892180073931980134853, TEST_CURVE),  # noqa: E501
+
+    # equal to sum of last two elements
+    Point(31969263762581634541702420136595781625976564652055998641927499388080005620826,
+          31851650165997003853447983973612951129977622378317524209017259746316028027479,
+          TEST_CURVE)
+]
+
+
+async def run_test_prog(prog, test_preprocessing=None, n=4, t=1, k=2000):
+    if test_preprocessing is not None:
+        test_preprocessing.generate("rands", n, t, k=k)
+        test_preprocessing.generate("triples", n, t, k=k)
+
+    program_runner = TaskProgramRunner(
+        n, t, {
+            MixinOpName.MultiplyShare: BeaverTriple.multiply_shares,
+            MixinOpName.InvertShare: Inverter.invert_share})
+    program_runner.add(prog)
+    await(program_runner.join())
+
+
+async def shared_point_equals(a, b):
+    if a.curve != b.curve:
+        return False
+    elif type(a) != type(b):
+        return False
+    elif isinstance(a, SharedIdeal):
+        return True
+    elif isinstance(a, Ideal):
+        return True
+
+    a_actual = (await(a.xs.open()), await(a.ys.open()))
+    b_actual = (await(b.xs.open()), await(b.ys.open()))
+    return a_actual == b_actual
+
+
+def test_basic_point_functionality():
+    p1 = TEST_POINTS[0]
+    ideal = Ideal(TEST_CURVE)
+
+    assert TEST_CURVE.contains_point(p1)
+    assert 2 * p1 == p1
+    assert p1.double() == 2 * p1
+
+    p2 = TEST_POINTS[1]
+    assert p2 + ideal == p2
+    assert p1 + p2 == p2
+    assert p2.double() == p2 * 2
+    assert -2 * p2 == 2 * (-p2)
+    assert p2 - p2 == p1
+
+    p3 = TEST_POINTS[2]
+    assert p2 + p3 == TEST_POINTS[3]
+    assert p2 != p3
+
+    assert p3[0] == 10
+
+
+@mark.asyncio
+async def test_shared_point_equals():
+    async def _prog(context):
+        p1 = await(SharedPoint.from_point(context, TEST_POINTS[0]))
+        p2 = await(SharedPoint.from_point(context, TEST_POINTS[1]))
+        p3 = await(SharedPoint.create(context, context.Share(
+            0), context.Share(1), Jubjub(Jubjub.Field(-2))))
+
+        assert await shared_point_equals(p1, p1)
+        assert not await shared_point_equals(p1, p2)
+        assert not await shared_point_equals(p1, p3)
+
+    await run_test_prog(_prog)
+
+
+@mark.asyncio
+async def test_contains_shared_point(test_preprocessing):
+    async def _prog(context):
+        # Will throw an exception if not on the curve
+        await SharedPoint.create(context, context.Share(0), context.Share(1))
+
+        with raises(Exception) as e_info:
+            await SharedPoint.create(context, context.Share(0), context.Share(2))
+        assert ('Could not initialize Point' in str(e_info.value))
+
+    await run_test_prog(_prog, test_preprocessing)
+
+
+@mark.asyncio
+async def test_shared_point_creation_from_point():
+    async def _prog(context):
+        p1 = Point(0, 1)
+        p1s = await SharedPoint.from_point(context, p1)
+        p2 = await SharedPoint.create(context, context.Share(0), context.Share(1))
+        assert await shared_point_equals(p1s, p2)
+
+    await run_test_prog(_prog)
+
+
+@mark.asyncio
+async def test_shared_point_double():
+    async def _prog(context):
+        for point in TEST_POINTS:
+            shared = await SharedPoint.from_point(context, point)
+            shared_double = await SharedPoint.from_point(context, point.double())
+            assert await shared_point_equals(shared_double, await(shared.double()))
+
+    await run_test_prog(_prog)
+
+
+@mark.asyncio
+async def test_shared_point_neg(test_preprocessing):
+    async def _prog(context):
+        for point in TEST_POINTS:
+            shared = await SharedPoint.from_point(context, point)
+            shared_negated = await SharedPoint.from_point(context, -point)
+            assert await shared_point_equals(shared_negated, await(shared.neg()))
+
+    await run_test_prog(_prog, test_preprocessing)
+
+
+@mark.asyncio
+async def test_shared_point_add(test_preprocessing):
+    async def _prog(context):
+        p1, p2, p3, p4 = [
+            await SharedPoint.from_point(context, point) for point in TEST_POINTS]
+        ideal = SharedIdeal(TEST_CURVE)
+
+        assert await shared_point_equals(await p2.add(ideal), p2)
+        assert await shared_point_equals(await p1.add(p2), p2)
+        assert await shared_point_equals(await p2.add(p3), p4)
+
+    await run_test_prog(_prog, test_preprocessing)
+
+
+@mark.asyncio
+async def test_shared_point_sub(test_preprocessing):
+    async def _prog(context):
+        shared_test_points = [
+            await SharedPoint.from_point(context, point) for point in TEST_POINTS]
+
+        for (p1, p2) in zip(shared_test_points, shared_test_points):
+            assert await shared_point_equals(
+                await p1.sub(p2),
+                await p1.add(await p2.neg()))
+
+    await run_test_prog(_prog, test_preprocessing)
+
+
+@mark.asyncio
+async def test_shared_point_mul(test_preprocessing):
+    async def _prog(context):
+        p1 = await SharedPoint.from_point(context, TEST_POINTS[1])
+        p1_double = await p1.double()
+        p1_quad = await p1_double.double()
+
+        assert await shared_point_equals(
+            p1_quad,
+            await p1.mul(4))
+
+        assert await shared_point_equals(
+            await p1_quad.add(p1),
+            await p1.mul(5))
+
+    await run_test_prog(_prog, test_preprocessing)
+
+# Commented out for now-- this causes stop iteration errors when running all tests
+@mark.asyncio
+async def test_shared_point_montgomery_mul(test_preprocessing):
+    async def _prog(context):
+        p1 = await SharedPoint.from_point(context, TEST_POINTS[1])
+        p1_double = await p1.double()
+        p1_quad = await p1_double.double()
+
+        assert await shared_point_equals(
+            p1_quad,
+            await p1.montgomery_mul(4))
+
+        assert await shared_point_equals(
+            await p1_quad.add(p1),
+            await p1.montgomery_mul(5))
+
+    await run_test_prog(_prog, test_preprocessing)


### PR DESCRIPTION
This adds in a a sample application utilizing an implementation
of a Jubjub curve to perform arithmatic operations on secret shared
points on the curve.

The PR is against the `drake-implement-share-inversion` branch, as it relies on that functionality. This should be merged in against `dev` once #228 is merged in. Additionally, this also requires the functionality in #229 be merged into `dev` before this will work correctly.