### PR TITLE
Add wait_for_all to simulate non robust mode

### DIFF
--- a/honeybadgermpc/robust_reconstruction.py
+++ b/honeybadgermpc/robust_reconstruction.py
@@ -6,12 +6,14 @@ from honeybadgermpc.reed_solomon import IncrementalDecoder
 from honeybadgermpc.batch_reconstruction import fetch_one
 
 
-async def robust_reconstruct(field_futures, field, n, t, point):
+async def robust_reconstruct(field_futures, field, n, t, f, point, wait_for_all=False):
     use_fft = point.use_fft
     enc = EncoderFactory.get(point, Algorithm.FFT if use_fft else Algorithm.VANDERMONDE)
     dec = DecoderFactory.get(point, Algorithm.FFT if use_fft else Algorithm.VANDERMONDE)
     robust_dec = RobustDecoderFactory.get(t, point, algorithm=Algorithm.GAO)
-    incremental_decoder = IncrementalDecoder(enc, dec, robust_dec, t, 1, t)
+    incremental_decoder = IncrementalDecoder(enc, dec, robust_dec, t, 1, f)
+    if wait_for_all:
+        incremental_decoder._min_points_required = lambda: n
 
     async for (idx, d) in fetch_one(field_futures):
         incremental_decoder.add(idx, [d.value])

--- a/progs/triple_refinement.py
+++ b/progs/triple_refinement.py
@@ -46,7 +46,6 @@ async def refine_triples(context, a_dirty, b_dirty, c_dirty):
     assert len(a_dirty) == len(b_dirty) == len(c_dirty)
     m = len(a_dirty)
     d = m // 2 if m & m-1 == 0 else 2**(m-2).bit_length()
-    zeroes = d - m
     omega = get_omega(context.field, 4*d, 2)
     a, b, c, x, y, z = rename_and_unpack_inputs(
         context.field, a_dirty, b_dirty, c_dirty, d, m)
@@ -55,7 +54,7 @@ async def refine_triples(context, a_dirty, b_dirty, c_dirty):
     c = list(itertools.chain(*zip(c, c_rest)))
     c_all = context.poly.interp_extrap(c, omega)
     pq = c_all[1::2]
-    num_valid_triples = d - context.t + 1 - zeroes
+    num_valid_triples = (context.t+1)//2
     p_shares = map(context.Share, p[:num_valid_triples])
     q_shares = map(context.Share, q[:num_valid_triples])
     pq_shares = map(context.Share, pq[:num_valid_triples])

--- a/tests/progs/test_triple_refinement.py
+++ b/tests/progs/test_triple_refinement.py
@@ -22,6 +22,7 @@ async def test_triple_refinement(test_preprocessing):
         q = await asyncio.gather(*map(lambda x: x.open(), b))
         pq = await asyncio.gather(*map(lambda x: x.open(), ab))
         assert len(p) == len(q) == len(pq), "Invalid number of values generated"
+        assert len(p) == (t+1)//2
         for d, e, de in zip(p, q, pq):
             # print("\n[%d] %d * %d == %d" % (context.myid, d, e, de))
             assert d * e == de

--- a/tests/test_batch_reconstruction.py
+++ b/tests/test_batch_reconstruction.py
@@ -52,7 +52,7 @@ async def _get_reconstruction(test_router, secret_shares, n, t, fp, p, use_fft,
             ss = [fp(0) for _ in secret_shares[i]]
         else:
             ss = tuple(map(fp, secret_shares[i]))
-        towait.append(batch_reconstruct(ss, p, t, n, i, sends[i], recvs[i],
+        towait.append(batch_reconstruct(ss, p, t, n, t, i, sends[i], recvs[i],
                                         use_fft=use_fft))
     results = await asyncio.gather(*towait)
     return results

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -1,10 +1,12 @@
-from pytest import mark
+import asyncio
+from pytest import mark, raises
 from honeybadgermpc.mpc import TaskProgramRunner
 
 
 @mark.asyncio
 async def test_open_shares(test_preprocessing):
-    n, t = 3, 1
+    t = 1
+    n = 3*t+1
     number_of_secrets = 100
     test_preprocessing.generate("zeros", n, t)
 
@@ -23,3 +25,172 @@ async def test_open_shares(test_preprocessing):
     assert len(results) == n
     assert all(len(secrets) == number_of_secrets for secrets in results)
     assert all(secret == 0 for secrets in results for secret in secrets)
+
+
+@mark.asyncio
+async def test_wait_for_all(test_preprocessing):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("zeros", n, t)
+
+    async def _prog(context):
+        if context.myid != 0:
+            # This should fail because we want to wait
+            # for all and 0th node did not send any value.
+            with raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    test_preprocessing.elements.get_zero(context).open(
+                        wait_for_all=True), 0.5)
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    await program_runner.join()
+
+
+@mark.asyncio
+async def test_wait_for_all_share_array(test_preprocessing):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("zeros", n, t)
+
+    async def _prog(context):
+        if context.myid != 0:
+            # This should fail because we want to wait
+            # for all and 0th node did not send any value.
+            with raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    context.ShareArray([test_preprocessing.elements.get_zero(
+                        context).v for i in range(10)]).open(
+                        wait_for_all=True), 0.5)
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    await program_runner.join()
+
+
+@mark.asyncio
+async def test_t_faults(test_preprocessing, galois_field):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("zeros", n, t)
+
+    async def _prog(context):
+        if context.myid != 0:
+            share = await test_preprocessing.elements.get_zero(context).open()
+        else:
+            # 0th node sends a faulty value.
+            share = await context.Share(galois_field.random()).open()
+        return share
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    results = await program_runner.join()
+    assert len(results) == n
+    assert len(set(results)) == 1
+    assert results[0] == 0
+
+
+@mark.asyncio
+async def test_t_faults_share_array(test_preprocessing, galois_field):
+    t = 1
+    n = 3*t+1
+    k = 10
+    test_preprocessing.generate("zeros", n, t)
+
+    async def _prog(context):
+        if context.myid != 0:
+            shares = await context.ShareArray([test_preprocessing.elements.get_zero(
+                context).v for i in range(10)]).open()
+        else:
+            # 0th node sends a faulty value.
+            shares = await context.ShareArray(
+                [galois_field.random() for _ in range(k)]).open()
+        return shares
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    secrets = await program_runner.join()
+    assert len(secrets) == n
+    assert all(len(secrets) == k for secrets in secrets)
+    assert all(secret == 0 for secrets in secrets for secret in secrets)
+
+
+@mark.asyncio
+async def test_more_than_t_faults_fail_with_timeout(test_preprocessing, galois_field):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("zeros", n, t)
+
+    async def _prog(context):
+        # This fails because we have more than `t` faults.
+        with raises(asyncio.TimeoutError):
+            if context.myid in [0, 1]:
+                await asyncio.wait_for(
+                    test_preprocessing.elements.get_zero(context).open(), 0.5)
+            else:
+                await asyncio.wait_for(context.Share(galois_field.random()).open(), 0.5)
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    await program_runner.join()
+
+
+@mark.asyncio
+async def test_more_than_t_faults_fail_with_timeout_share_array(
+        test_preprocessing, galois_field):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("zeros", n, t)
+
+    async def _prog(context):
+        # This fails because we have more than `t` faults.
+        if context.myid in [0, 1]:
+            shares = await asyncio.wait_for(context.ShareArray(
+                [galois_field.random() for i in range(10)]).open(), 0.5)
+        else:
+            shares = await asyncio.wait_for(
+                context.ShareArray([test_preprocessing.elements.get_zero(
+                    context).v for i in range(10)]).open(), 0.5)
+        assert shares is None
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    await program_runner.join()
+
+
+@mark.asyncio
+async def test_double_share(test_preprocessing):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("rands", n, 2*t)
+
+    async def _prog(context):
+        # 0th node does not send a value so this should hang.
+        if context.myid != 0:
+            with raises(asyncio.TimeoutError):
+                share = await asyncio.wait_for(
+                    test_preprocessing.elements.get_rand(context, 2*t).open(), 0.5)
+                return share
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    await program_runner.join()
+
+
+@mark.asyncio
+async def test_double_share_array(test_preprocessing):
+    t = 1
+    n = 3*t+1
+    test_preprocessing.generate("rands", n, 2*t)
+
+    async def _prog(context):
+        # 0th node does not send a value so this should hang.
+        if context.myid != 0:
+            with raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    context.ShareArray([test_preprocessing.elements.get_rand(
+                        context, 2*t).v for i in range(10)], 2*t).open(), 0.5)
+
+    program_runner = TaskProgramRunner(n, t)
+    program_runner.add(_prog)
+    await program_runner.join()


### PR DESCRIPTION
* Add `wait_for_all` to simulate non robust mode wherein we wait for all
values during reconstruction.
* Demonstrate using test cases how we can pass faulty values and things
continue to work during reconstruction.