### PR TITLE
Add mult_share function for <share> * <plain_point>

### DIFF
--- a/honeybadgermpc/progs/jubjub.py
+++ b/honeybadgermpc/progs/jubjub.py
@@ -1,6 +1,5 @@
-from honeybadgermpc.elliptic_curve import Jubjub, Point
+from honeybadgermpc.elliptic_curve import Jubjub, Point, Ideal
 from honeybadgermpc.mpc import Mpc
-import asyncio
 
 
 class SharedPoint(object):
@@ -19,13 +18,10 @@ class SharedPoint(object):
         self.xs = xs
         self.ys = ys
 
-    async def __on_curve(self) -> bool:
+    async def _on_curve(self) -> bool:
         """
         Checks whether or not the given shares for x and y correspond to a
         point that sits on the current curve
-
-        WARNING: This method currently leaks information about the shared point--
-                 We need to use share equality testing instead
         """
         x_sq = self.xs * self.xs
         y_sq = self.ys * self.ys
@@ -36,17 +32,7 @@ class SharedPoint(object):
         # 1 + dx^2y^2
         rhs = self.context.field(1) + self.curve.d * x_sq * y_sq
 
-        # TODO: use share equality to prevent the leaking of data
-        lhs, rhs = await asyncio.gather(lhs.open(), rhs.open())
-        return lhs == rhs
-
-    async def __init(self):
-        """asynchronous part of initialization via create or from_point
-        """
-        if not await self.__on_curve():
-            raise ValueError(
-                f"Could not initialize Point {self}-- \
-                does not sit on given curve {self.curve}")
+        return await (await lhs == await rhs).open()
 
     @staticmethod
     async def create(context: Mpc, xs, ys, curve=Jubjub()):
@@ -54,18 +40,22 @@ class SharedPoint(object):
             creates the given point
         """
         point = SharedPoint(context, xs, ys, curve)
-        await point.__init()
+        if not await point._on_curve():
+            raise ValueError(
+                f"Could not initialize Point {point}-- \
+                does not sit on given curve {point.curve}")
 
         return point
 
     @staticmethod
-    async def from_point(context: Mpc, p: Point) -> 'SharedPoint':
+    def from_point(context: Mpc, p: Point) -> 'SharedPoint':
         """ Given a local point and a context, created a shared point
         """
         if not isinstance(p, Point):
             raise Exception(f"Could not create shared point-- p ({p}) is not a Point!")
 
-        return await(SharedPoint.create(context, context.Share(p.x), context.Share(p.y)))
+        return SharedPoint(context, context.Share(p.x),
+                           context.Share(p.y), curve=p.curve)
 
     def __str__(self) -> str:
         return f"({self.xs}, {self.ys})"
@@ -73,11 +63,11 @@ class SharedPoint(object):
     def __repr__(self) -> str:
         return str(self)
 
-    async def neg(self):
-        return await SharedPoint.create(self.context,
-                                        self.context.field(-1) * self.xs,
-                                        self.ys,
-                                        self.curve)
+    def neg(self):
+        return SharedPoint(self.context,
+                           -1 * self.xs,
+                           self.ys,
+                           self.curve)
 
     async def add(self, other: 'SharedPoint') -> 'SharedPoint':
         if isinstance(other, SharedIdeal):
@@ -104,10 +94,10 @@ class SharedPoint(object):
         # y3 = ((y1*y2) + (x1*x2)) / (1 - d*x1*x2*y1*y2)
         y3 = (y_prod + x_prod) / (one - d_prod)
 
-        return await SharedPoint.create(self.context, x3, y3, self.curve)
+        return SharedPoint(self.context, x3, y3, self.curve)
 
     async def sub(self, other: 'SharedPoint') -> 'SharedPoint':
-        return await self.add(await other.neg())
+        return await self.add(other.neg())
 
     async def mul(self, n: int) -> 'SharedPoint':
         # Using the Double-and-Add algorithm
@@ -116,13 +106,12 @@ class SharedPoint(object):
             raise Exception("Can't scale a SharedPoint by something which isn't an int!")
 
         if n < 0:
-            negated = await self.neg()
-            return await negated.mul(-n)
+            return await self.neg().mul(-n)
         elif n == 0:
             return SharedIdeal(self.curve)
 
         current = self
-        product = await SharedPoint.from_point(self.context, Point(0, 1, self.curve))
+        product = SharedPoint.from_point(self.context, Point(0, 1, self.curve))
 
         i = 1
         while i <= n:
@@ -147,7 +136,7 @@ class SharedPoint(object):
             return SharedIdeal(self.curve)
 
         current = self
-        product = await SharedPoint.from_point(self.context, Point(0, 1, self.curve))
+        product = SharedPoint.from_point(self.context, Point(0, 1, self.curve))
 
         i = 1 << n.bit_length()
         while i > 0:
@@ -173,10 +162,7 @@ class SharedPoint(object):
         x = (2 * x_ * y_) / x_denom
         y = (y_sq - ax_sq) / (self.context.field(2) - x_denom)
 
-        return await SharedPoint.create(self.context,
-                                        x,
-                                        y,
-                                        self.curve)
+        return SharedPoint(self.context, x, y, self.curve)
 
 
 class SharedIdeal(SharedPoint):
@@ -219,3 +205,42 @@ class SharedIdeal(SharedPoint):
 
     async def double(self):
         return self
+
+
+async def share_mul(context: Mpc, bs: list, p: Point) -> SharedPoint:
+    """
+    The multiplication of the share of a field element and a point
+    e.g. [x]P -> [X], where P is a point on the given elliptic curve
+    x is the bitwise shared value,
+    starting from the least significant bit.
+
+    NOTE: This is an affine version.
+    bs := [[b0], [b1], ... [bK]], then bs * P can be broken down into
+    [b0] * (2^0 * P) + [b1] * (2^1 * P) .... + [bK] * (2^K * P)
+
+    For each term [bi] * (2^i * P), we compute its x, y coordinates seperately.
+    Let P2i := (2^i * P), and we have identity = (0, 1), then
+        x = [b_i] * (P2i.x - identity.x) + identity.x
+          = [b_i] * P2i.x
+        y = [b_i] * (P2i.y - identity.y) + identity.y
+          = [b_i] * (P2i.y - 1) + 1
+    So we get the SharedPoint of each term.
+    """
+    if isinstance(p, Ideal):
+        return SharedIdeal(p.curve)
+
+    terms = []
+    p2i = p
+    for i in range(len(bs)):
+        term = SharedPoint(context,
+                           p2i.x * bs[i],
+                           (p2i.y - 1) * bs[i] + p.curve.Field(1),
+                           p.curve)
+        terms.append(term)
+        p2i = p2i.double()
+
+    accum = terms[0]
+    for i in terms[1:]:
+        accum = await accum.add(i)
+
+    return accum

--- a/honeybadgermpc/router.py
+++ b/honeybadgermpc/router.py
@@ -1,5 +1,5 @@
 import asyncio
-import logging
+# import logging
 
 
 def simple_router(n):
@@ -12,7 +12,7 @@ def simple_router(n):
 
     def make_send(i):
         def _send(j, o):
-            logging.debug('SEND %8s [%2d -> %2d]' % (o, i, j))
+            # logging.debug('SEND %8s [%2d -> %2d]' % (o, i, j))
             # delay = random.random() * 1.0
             # asyncio.get_event_loop().call_later(delay, mbox[j].put_nowait,(i,o))
             mbox[j].put_nowait((i, o))
@@ -22,7 +22,7 @@ def simple_router(n):
     def make_recv(j):
         async def _recv():
             (i, o) = await mbox[j].get()
-            logging.debug('RECV %8s [%2d -> %2d]' % (o, i, j))
+            # logging.debug('RECV %8s [%2d -> %2d]' % (o, i, j))
             return (i, o)
 
         return _recv

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -1,7 +1,7 @@
 import asyncio
 from pytest import mark, raises
 from honeybadgermpc.elliptic_curve import Ideal, Point, Jubjub
-from honeybadgermpc.progs.jubjub import SharedPoint, SharedIdeal
+from honeybadgermpc.progs.jubjub import SharedPoint, SharedIdeal, share_mul
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays, Equality)
@@ -31,7 +31,7 @@ STANDARD_ARITHMETIC_MIXINS = [
 ]
 
 STANDARD_PREPROCESSING = [
-    'rands', 'triples'
+    'rands', 'triples', 'bits'
 ]
 
 n, t = 4, 1
@@ -82,8 +82,8 @@ def test_basic_point_functionality():
 @mark.asyncio
 async def test_shared_point_equals(test_preprocessing, test_runner):
     async def _prog(context):
-        p1 = await SharedPoint.from_point(context, TEST_POINTS[0])
-        p2 = await SharedPoint.from_point(context, TEST_POINTS[1])
+        p1 = SharedPoint.from_point(context, TEST_POINTS[0])
+        p2 = SharedPoint.from_point(context, TEST_POINTS[1])
         p3 = await SharedPoint.create(context, context.Share(
             0), context.Share(1), Jubjub(Jubjub.Field(-2)))
 
@@ -110,7 +110,7 @@ async def test_contains_shared_point(test_preprocessing, test_runner):
 async def test_shared_point_creation_from_point(test_preprocessing, test_runner):
     async def _prog(context):
         p1 = Point(0, 1)
-        p1s = await SharedPoint.from_point(context, p1)
+        p1s = SharedPoint.from_point(context, p1)
         p2 = await SharedPoint.create(context, context.Share(0), context.Share(1))
         assert await shared_point_equals(p1s, p2)
 
@@ -120,10 +120,9 @@ async def test_shared_point_creation_from_point(test_preprocessing, test_runner)
 @mark.asyncio
 async def test_shared_point_double(test_preprocessing, test_runner):
     async def _prog(context):
-        shared_points, actual_doubled = await asyncio.gather(
-            asyncio.gather(*[SharedPoint.from_point(context, p) for p in TEST_POINTS]),
-            asyncio.gather(*[SharedPoint.from_point(context, p.double())
-                             for p in TEST_POINTS]))
+        shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
+        actual_doubled = [SharedPoint.from_point(
+            context, p.double()) for p in TEST_POINTS]
 
         results = await asyncio.gather(*[p.double() for p in shared_points])
         assert all(await asyncio.gather(
@@ -135,17 +134,13 @@ async def test_shared_point_double(test_preprocessing, test_runner):
 @mark.asyncio
 async def test_shared_point_neg(test_preprocessing, test_runner):
     async def _prog(context):
-        shared_points, actual_negated = await asyncio.gather(
-            asyncio.gather(
-                *[SharedPoint.from_point(context, p) for p in TEST_POINTS]),
-            asyncio.gather(
-                *[SharedPoint.from_point(context, -p) for p in TEST_POINTS]))
+        shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
+        actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
 
-        shared_negated = await asyncio.gather(*[s.neg() for s in shared_points])
+        shared_negated = [s.neg() for s in shared_points]
 
         zipped = zip(actual_negated, shared_negated)
-        assert all(await asyncio.gather(
-            *[shared_point_equals(a, r) for a, r in zipped]))
+        assert all(await asyncio.gather(*[shared_point_equals(a, r) for a, r in zipped]))
 
     await run_test_program(_prog, test_runner)
 
@@ -155,8 +150,8 @@ async def test_shared_point_add(test_preprocessing, test_runner):
     async def _prog(context):
         ideal = SharedIdeal(TEST_CURVE)
 
-        p1, p2, p3, p4 = await asyncio.gather(
-            *[SharedPoint.from_point(context, point) for point in TEST_POINTS])
+        p1, p2, p3, p4 = [SharedPoint.from_point(
+            context, point) for point in TEST_POINTS]
 
         r1, r2, r3 = await asyncio.gather(
             p2.add(ideal),
@@ -175,17 +170,14 @@ async def test_shared_point_add(test_preprocessing, test_runner):
 @mark.asyncio
 async def test_shared_point_sub(test_preprocessing, test_runner):
     async def _prog(context):
-        shared_points, actual_negated = await asyncio.gather(
-            asyncio.gather(
-                *[SharedPoint.from_point(context, p) for p in TEST_POINTS]),
-            asyncio.gather(
-                *[SharedPoint.from_point(context, -p) for p in TEST_POINTS]))
+        shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
+        actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
 
         # We're going to be testing that given point p, p - p == p + (-p)
         actual, result = await asyncio.gather(
             asyncio.gather(*[p.sub(p) for p in shared_points]),
             asyncio.gather(*[p1.add(p2)
-                             for p1, p2 in zip(shared_points, actual_negated)]))
+                           for p1, p2 in zip(shared_points, actual_negated)]))
 
         assert all(await asyncio.gather(
             *[shared_point_equals(a, r) for a, r in zip(actual, result)]))
@@ -196,7 +188,7 @@ async def test_shared_point_sub(test_preprocessing, test_runner):
 @mark.asyncio
 async def test_shared_point_mul(test_preprocessing, test_runner):
     async def _prog(context):
-        p1 = await SharedPoint.from_point(context, TEST_POINTS[1])
+        p1 = SharedPoint.from_point(context, TEST_POINTS[1])
         p1_double = await p1.double()
         p1_quad = await p1_double.double()
         p4 = await p1.mul(4)
@@ -212,7 +204,7 @@ async def test_shared_point_mul(test_preprocessing, test_runner):
 @mark.asyncio
 async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
     async def _prog(context):
-        p1 = await SharedPoint.from_point(context, TEST_POINTS[1])
+        p1 = SharedPoint.from_point(context, TEST_POINTS[1])
         p1_double = await p1.double()
         p1_quad = await p1_double.double()
 
@@ -223,5 +215,39 @@ async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
         assert await shared_point_equals(
             await p1_quad.add(p1),
             await p1.montgomery_mul(5))
+
+    await run_test_program(_prog, test_runner)
+
+
+@mark.asyncio
+async def test_share_mul(test_preprocessing, test_runner):
+    # bit_length = 255
+    bit_length = 80  # Short key for testing
+    test_preprocessing.generate('bits', n, t, k=2000)
+
+    async def _prog(context):
+        p = TEST_POINTS[1]
+        multiplier_ = [test_preprocessing.elements.get_bit(context)
+                       for i in range(bit_length)]
+        multiplier = Jubjub.Field(0)
+        for i in range(bit_length):
+            multiplier += (2**i) * multiplier_[i]
+        multiplier = await multiplier.open()
+        p_mul = int(multiplier) * p
+
+        # Compute share_mul
+        p1_ = await share_mul(context, multiplier_, p)
+        px, py = await asyncio.gather(p1_.xs.open(), p1_.ys.open())
+
+        # Assertation
+        if multiplier == Jubjub.Field(0):
+            assert (px, py) == (Jubjub.Field(0), Jubjub.Field(1))
+        else:
+            assert px == p_mul.x
+            assert py == p_mul.y
+
+        q1_ = await share_mul(context, multiplier_, Ideal(TEST_CURVE))
+        q2_ = SharedIdeal(TEST_CURVE)
+        assert await shared_point_equals(q1_, q2_)
 
     await run_test_program(_prog, test_runner)


### PR DESCRIPTION
The input is a bitwise shared value,` [a1, a2, a3, ... ak]` where `ai` is the shared value of 0 or 1, and a plain point. 
Each of the bit share is opened in the iterator to check if it's equal to 1, which looks not safe. But given that the equality application hasn't been merged, let's take it as a tentative solution.