### PR TITLE
HBAVSS: implement implicate handling and share recovery

### DIFF
--- a/honeybadgermpc/betterpairing.py
+++ b/honeybadgermpc/betterpairing.py
@@ -668,6 +668,9 @@ class ZR:
                 'Invalid division param. Expected ZR or int. Got '
                 + str(type(other)))
 
+    def __rtruediv__(self, other):
+        return ZR(other).__truediv__(self)
+
     def __pow__(self, other):
         if type(other) is int:
             exponend = ZR(other % (bls12_381_r-1))
@@ -717,3 +720,30 @@ class ZR:
     @staticmethod
     def one():
         return ZR(PyFr("1"))
+
+
+def lagrange_at_x(s, j, x):
+    s = sorted(s)
+    assert j in s
+    l1 = [x - jj for jj in s if jj != j]
+    l2 = [j - jj for jj in s if jj != j]
+    (num, den) = (ZR(1), ZR(1))
+    for item in l1:
+        num *= item
+    for item in l2:
+        den *= item
+    return num / den
+
+
+def interpolate_g1_at_x(coords, x, order=-1):
+    if order == -1:
+        order = len(coords)
+    xs = []
+    sortedcoords = sorted(coords, key=lambda x: x[0])
+    for coord in sortedcoords:
+        xs.append(coord[0])
+    s = set(xs[0:order])
+    out = G1.one()
+    for i in range(order):
+        out = out * (sortedcoords[i][1] ** (lagrange_at_x(s, xs[i], x)))
+    return out

--- a/honeybadgermpc/hbavss.py
+++ b/honeybadgermpc/hbavss.py
@@ -1,12 +1,11 @@
 import logging
 import asyncio
 from pickle import dumps, loads
-from honeybadgermpc.betterpairing import ZR
+from honeybadgermpc.betterpairing import ZR, interpolate_g1_at_x
 from honeybadgermpc.polynomial import polynomials_over
 from honeybadgermpc.poly_commit_const import PolyCommitConst
 from honeybadgermpc.poly_commit_lin import PolyCommitLin
 from honeybadgermpc.symmetric_crypto import SymmetricCrypto
-from honeybadgermpc.exceptions import HoneyBadgerMPCError
 from honeybadgermpc.protocols.reliablebroadcast import reliablebroadcast
 from honeybadgermpc.protocols.avid import AVID
 from honeybadgermpc.utils import wrap_send
@@ -23,8 +22,11 @@ logger.setLevel(logging.ERROR)
 
 class HbAVSSMessageType:
     OK = "OK"
-    # IMPLICATE = "IMPLICATE"
+    IMPLICATE = "IMPLICATE"
     READY = "READY"
+    RECOVERY = "RECOVERY"
+    RECOVERY1 = "RECOVERY1"
+    RECOVERY2 = "RECOVERY2"
 
 
 class HbAvssLight():
@@ -55,6 +57,24 @@ class HbAvssLight():
     def __exit__(self, type, value, traceback):
         self.subscribe_recv_task.cancel()
 
+    def _handle_implication(self, commitment, ephemeral_public_key, j, j_sk, j_z):
+        """
+        Handle the implication of AVSS.
+        Return True if the implication is valid, False otherwise.
+        """
+        # discard if PKj ! = g^SKj
+        if self.public_keys[j] != pow(self.g, j_sk):
+            return False
+        # decrypt and verify
+        j_shared_key = pow(ephemeral_public_key, j_sk)
+        try:
+            j_share, j_aux = SymmetricCrypto.decrypt(
+                str(j_shared_key).encode(), j_z)
+        except Exception:  # TODO: specific exception
+            return True
+        return not self.poly_commit.verify_eval(
+                commitment, j+1, j_share, j_aux)
+
     async def _process_avss_msg(self, avss_id, dealer_id, avss_msg):
         tag = f"{dealer_id}-{avss_id}-AVSS"
         send, recv = self.get_send(tag), self.subscribe_recv(tag)
@@ -63,44 +83,78 @@ class HbAvssLight():
             for i in range(self.n):
                 send(i, msg)
 
-        commitments, ephemeral_public_key, encrypted_witnesses = loads(avss_msg)
+        commitment, ephemeral_public_key, encrypted_blobs = loads(avss_msg)
         shared_key = pow(ephemeral_public_key, self.private_key)
-        share, witness = SymmetricCrypto.decrypt(
-            str(shared_key).encode("utf-8"), encrypted_witnesses[self.my_id])
-        if self.poly_commit.verify_eval(commitments, self.my_id+1, share, witness):
-            multicast(HbAVSSMessageType.OK)
-        else:
-            logging.error("PolyCommit verification failed.")
-            raise HoneyBadgerMPCError("PolyCommit verification failed.")
+        share_valid = True
+        try:
+            share, witness = SymmetricCrypto.decrypt(
+                str(shared_key).encode(), encrypted_blobs[self.my_id])
+            if self.poly_commit.verify_eval(commitment, self.my_id+1, share, witness):
+                multicast((HbAVSSMessageType.OK, ""))
+            else:
+                multicast((HbAVSSMessageType.IMPLICATE, self.private_key))
+                share_valid = False
+        except Exception:  # TODO specific exceptions
+            multicast((HbAVSSMessageType.IMPLICATE, self.private_key))
+            share_valid = False
 
-        # to handle the case that a (malicious) node sends
-        # an OK message multiple times
+        # RECEIVE LOOP
         ok_set = set()
-        while len(ok_set) < 2 * self.t + 1:
-            sender, avss_msg = await recv()  # First value is the `sid`
-            if avss_msg == HbAVSSMessageType.OK and sender not in ok_set:
+        recovery_shares = []
+        sent_recovery = False
+        output = False
+        while True:
+            if len(ok_set) == 2 * self.t + 1 and share_valid and not output:
+                share_int = int(share)
+                self.output_queue.put_nowait((dealer_id, avss_id, share_int))
+                output = True
+            elif len(recovery_shares) == self.t + 1 and not output:
+                share_int = int(self.poly.interpolate_at(recovery_shares, self.my_id+1))
+                self.output_queue.put_nowait((dealer_id, avss_id, share_int))
+                output = True
+                share_valid = True
+            # We can safely stop running at this point
+            if len(ok_set) == self.n:
+                break
+            sender, avss_msg = await recv()  # First value is `sid` (not true anymore?)
+            if avss_msg[0] == HbAVSSMessageType.OK and sender not in ok_set:
                 ok_set.add(sender)
-
-        # Output the share as an integer so it is not tied to a type like ZR/GFElement
-        share_int = int(share)
-        self.output_queue.put_nowait((dealer_id, avss_id, share_int))
-
-        logger.debug("[%d] 2t+1 OKs received.", self.my_id)
-        return share_int
+            if avss_msg[0] == HbAVSSMessageType.IMPLICATE \
+                    and not sent_recovery and share_valid:
+                j_sk = avss_msg[1]
+                j = sender
+                # validate the implicate
+                if not self._handle_implication(
+                        commitment, ephemeral_public_key, j, j_sk, encrypted_blobs[j]):
+                    # Count an invalid implicate as an okay
+                    if sender not in ok_set:
+                        ok_set.add(sender)
+                    continue
+                sent_recovery = True
+                multicast((HbAVSSMessageType.RECOVERY, self.private_key))
+            if avss_msg[0] == HbAVSSMessageType.RECOVERY and not share_valid:
+                try:
+                    share_j, aux_j = SymmetricCrypto.decrypt(
+                        str(ephemeral_public_key**avss_msg[1]).encode(), encrypted_blobs[sender])  # (# noqa: E501)
+                except Exception:
+                    ok_set.add(sender)
+                    continue
+                if self.poly_commit.verify_eval(commitment, sender+1, share_j, aux_j):
+                    if ([sender+1, share_j] not in recovery_shares):
+                        recovery_shares.append([sender+1, share_j])
 
     def _get_dealer_msg(self, value):
         phi = self.poly.random(self.t, value)
-        commitments, aux_poly = self.poly_commit.commit(phi)
+        commitment, aux_poly = self.poly_commit.commit(phi)
         ephemeral_secret_key = self.field.random()
         ephemeral_public_key = pow(self.g, ephemeral_secret_key)
         z = [None]*self.n
         for i in range(self.n):
             witness = self.poly_commit.create_witness(aux_poly, i+1)
             shared_key = pow(self.public_keys[i], ephemeral_secret_key)
-            z[i] = SymmetricCrypto.encrypt(
-                str(shared_key).encode("utf-8"), (phi(i+1), witness))
+            z[i] = SymmetricCrypto.encrypt(str(shared_key).encode(), (phi(i+1), witness))
 
-        return dumps((commitments, ephemeral_public_key, z))
+        return dumps((commitment, ephemeral_public_key, z))
 
     async def avss(self, avss_id, value=None, dealer_id=None, client_mode=False):
         """
@@ -171,9 +225,8 @@ class HbAvssLight():
             return
 
         logger.debug("[%d] RBC completed.", self.my_id)
-        share = await self._process_avss_msg(avss_id, dealer_id, avss_msg)
+        await self._process_avss_msg(avss_id, dealer_id, avss_msg)
         logger.debug("[%d] AVSS [%s] completed.", self.my_id, avss_id)
-        return share
 
     async def avss_parallel(self, avss_id, k, values=None, dealer_id=None):
         """
@@ -213,6 +266,7 @@ class HbAvssBatch():
 
         self.avid_msg_queue = asyncio.Queue()
         self.tasks = []
+        self.shares_future = asyncio.Future()
 
     async def _recv_loop(self, q):
         while True:
@@ -230,7 +284,28 @@ class HbAvssBatch():
         for task in self.tasks:
             task.cancel()
 
-    async def _process_avss_msg(self, avss_id, dealer_id, dispersal_msg):
+    async def _handle_implication(
+            self, avid, tag, ephemeral_public_key, commitments, j, j_pk, j_k):
+        """
+        Handle the implication of AVSS.
+        Return True if the implication is valid, False otherwise.
+        """
+        # discard if PKj ! = g^SKj
+        if self.public_keys[j] != pow(self.g, j_pk):
+            return False
+        # decrypt and verify
+        implicate_msg = await avid.retrieve(tag, j)
+        j_z = loads(implicate_msg)
+        j_shared_key = pow(ephemeral_public_key, j_pk)
+        try:
+            j_share, j_aux, j_witnesses = SymmetricCrypto.decrypt(
+                str(j_shared_key).encode(), j_z[j_k])
+        except Exception:
+            return True
+        return not self.poly_commit.verify_eval(
+                commitments[j_k], j+1, j_share, j_aux, j_witnesses)
+
+    async def _process_avss_msg(self, avss_id, dealer_id, rbc_msg, avid):
         tag = f"{dealer_id}-{avss_id}-B-AVSS"
         send, recv = self.get_send(tag), self.subscribe_recv(tag)
 
@@ -238,49 +313,135 @@ class HbAvssBatch():
             for i in range(self.n):
                 send(i, msg)
 
-        commitments, ephemeral_public_key, encrypted_witnesses = loads(
-            dispersal_msg)
+        # get phi and public key from reliable broadcast msg
+        commitments, ephemeral_public_key = loads(rbc_msg)
+        # retrieve the z
+        dispersal_msg = await avid.retrieve(tag, self.my_id)
+        encrypted_witnesses = loads(dispersal_msg)
+
         secret_size = len(commitments)
 
         # all_encrypted_witnesses: n
         shared_key = pow(ephemeral_public_key, self.private_key)
 
         shares = [None] * secret_size
+        auxes = [None] * secret_size
+        witnesses = [None] * secret_size
         # Decrypt
+        all_shares_valid = True
         for k in range(secret_size):
-            shares[k], cur_aux, witness = SymmetricCrypto.decrypt(
-                str(shared_key).encode("utf-8"), encrypted_witnesses[k])
+            try:
+                shares[k], auxes[k], witnesses[k] = SymmetricCrypto.decrypt(
+                    str(shared_key).encode(), encrypted_witnesses[k])
+            except Exception:
+                all_shares_valid = False
+                multicast((HbAVSSMessageType.IMPLICATE, self.private_key, k))
+                break
             if not self.poly_commit.verify_eval(
-                    commitments[k], self.my_id+1, shares[k], cur_aux, witness):
-                # will be replaced by sending out IMPLICATE message later
-                # multicast(HbAVSSMessageType.IMPLICATE)
-                logging.error("PolyCommit verification failed.")
-                raise HoneyBadgerMPCError("PolyCommit verification failed.")
+                    commitments[k], self.my_id+1, shares[k], auxes[k], witnesses[k]):
+                # invalid share found and send all implicate msg
+                all_shares_valid = False
+                multicast((HbAVSSMessageType.IMPLICATE, self.private_key, k))
+                break
 
-        multicast(HbAVSSMessageType.OK)
+        if all_shares_valid:
+            multicast((HbAVSSMessageType.OK, ""))
 
-        # Bracha-style agreement
-        # to handle the case that a (malicious) node sends
-        # an OK or READY message multiple times
         ok_set = set()
         ready_set = set()
-        # if 2t+1 OK or t+1 READY -> send all ready
-        while len(ok_set) < 2 * self.t + 1 and len(ready_set) < self.t + 1:
-            sender, avss_msg = await recv()  # First value is the `sid`
-            if avss_msg == HbAVSSMessageType.OK and sender not in ok_set:
+        r1_set = set()
+        r2_set = set()
+        ready_sent = r1_sent = r2_sent = False
+        r1_phi = [None] * self.n
+        r2_phi = [None] * self.n
+
+        while True:
+            # main recv loop for Bracha-style agreement and implicate handling
+            sender, avss_msg = await recv()
+            # OK
+            if avss_msg[0] == HbAVSSMessageType.OK and sender not in ok_set:
                 ok_set.add(sender)
-            elif avss_msg == HbAVSSMessageType.READY and sender not in ready_set:
+            # READY
+            if avss_msg[0] == HbAVSSMessageType.READY and sender not in ready_set:
                 ready_set.add(sender)
+            # IMPLICATE
+            if avss_msg[0] == HbAVSSMessageType.IMPLICATE:
+                # validate the implicate
+                if not await self._handle_implication(
+                        avid, tag, ephemeral_public_key, commitments,
+                        sender, avss_msg[1], avss_msg[2]):
+                    continue
+                # proceed to share recovery
+                logger.debug("[%d] Share recovery activated by %d", self.my_id, sender)
+                # setup the coordinates for interpolation
+                c_coords = [None] * secret_size
+                phi_coords = [None] * secret_size
+                aux_coords = [None] * secret_size
+                w_coords = [None] * secret_size
+                for i in range(secret_size):
+                    c_coords[i] = (i, commitments[i])
+                    phi_coords[i] = (i, shares[i])
+                    aux_coords[i] = (i, auxes[i])
+                    w_coords[i] = (i, witnesses[i])
+                # interpolate commitments
+                interpolated_c = [None] * self.n
+                for i in range(self.n):
+                    interpolated_c[i] = interpolate_g1_at_x(c_coords, i)
+                # if my shares are valid
+                if not r1_sent and all_shares_valid:
+                    r1_sent = True
+                    phi_i = self.poly.interpolate(phi_coords)
+                    aux_i = self.poly.interpolate(aux_coords)
+                    for j in range(self.n):
+                        phi_i_j = phi_i(j)
+                        aux_i_j = aux_i(j)
+                        w_i_j = interpolate_g1_at_x(w_coords, j)
+                        send(j, (HbAVSSMessageType.RECOVERY1, phi_i_j, aux_i_j, w_i_j))
+            # R1
+            if avss_msg[0] == HbAVSSMessageType.RECOVERY1:
+                _, phi_k_i, aux_k_i, w_k_i = avss_msg
+                if self.poly_commit.verify_eval(
+                        interpolated_c[self.my_id], sender+1, phi_k_i, aux_k_i, w_k_i):
+                    r1_set.add(sender)
+                    r1_phi[sender] = phi_k_i
+            # R2
+            if avss_msg[0] == HbAVSSMessageType.RECOVERY2:
+                r2_set.add(sender)
+                r2_phi[sender] = avss_msg[1]
 
-        multicast(HbAVSSMessageType.READY)
+            # enough R1 received -> proceed to R2
+            if not r2_sent and len(r1_set) >= self.t + 1:
+                r2_sent = True
+                r1_phi_coords = [(i, r1_phi[i])
+                                 for i in range(self.n) if r1_phi[i] is not None]
+                phi_i = self.poly.interpolate(r1_phi_coords)
+                for j in range(self.n):
+                    phi_j_i = phi_i(j)
+                    send(j, (HbAVSSMessageType.RECOVERY2, phi_j_i))
 
-        # if 2t+1 ready -> output shares
-        while len(ready_set) < 2 * self.t + 1:
-            sender, avss_msg = await recv()  # First value is the `sid`
-            if avss_msg == HbAVSSMessageType.READY and sender not in ready_set:
-                ready_set.add(sender)
+            # enough R2 received -> output result
+            # Does this actually do robust interpolation?
+            if len(r2_set) >= 2 * self.t + 1:
+                recovered_result = [None] * secret_size
+                r2_phi_coords = [(i, r2_phi[i])
+                                 for i in range(self.n) if r2_phi[i] is not None]
+                r2_phi_poly = self.poly.interpolate(r2_phi_coords)
+                for k in range(secret_size):
+                    recovered_result[k] = r2_phi_poly(k)
+                if not self.shares_future.done():
+                    self.shares_future.set_result(recovered_result)
 
-        return shares
+            # if 2t+1 OK or t+1 READY -> send all ready
+            if not ready_sent and \
+                    (len(ok_set) >= 2 * self.t + 1 or len(ready_set) >= self.t + 1):
+                ready_sent = True
+                multicast((HbAVSSMessageType.READY, ""))
+
+            # if 2t+1 ready -> output shares
+            if len(ready_set) >= 2 * self.t + 1:
+                # output result by setting the future value
+                if all_shares_valid and not self.shares_future.done():
+                    self.shares_future.set_result(shares)
 
     def _get_dealer_msg(self, values):
         # Sample a random degree-(t,t) bivariate polynomial φ(·,·)
@@ -300,22 +461,21 @@ class HbAvssBatch():
         # for each party Pi and each k ∈ [t+1]
         #   1. w[i][k] <- CreateWitnesss(Ck,auxk,i)
         #   2. z[i][k] <- EncPKi(φ(i,k), w[i][k])
-        dealer_msg_list = [None] * self.n
+        dispersal_msg_list = [None] * self.n
         for i in range(self.n):
             shared_key = pow(self.public_keys[i], ephemeral_secret_key)
             z = [None] * secret_size
             for k in range(secret_size):
                 witness = self.poly_commit.create_witness(phi[k], aux_poly[k], i+1)
-                z[k] = SymmetricCrypto.encrypt(
-                    str(shared_key).encode("utf-8"),
-                    (phi[k](i+1), aux_poly[k](i+1), witness))
-            dealer_msg_list[i] = dumps((commitments, ephemeral_public_key, z))
+                z[k] = SymmetricCrypto.encrypt(str(shared_key).encode(),
+                                               (phi[k](i+1), aux_poly[k](i+1), witness))
+            dispersal_msg_list[i] = dumps(z)
 
-        return dealer_msg_list
+        return dumps((commitments, ephemeral_public_key)), dispersal_msg_list
 
     async def avss(self, avss_id, values=None, dealer_id=None, client_mode=False):
         """
-        A batched version of avss similar to the one in light version
+        A batched version of avss with share recovery
         """
         # If `values` is passed then the node is a 'Sender'
         # `dealer_id` must be equal to `self.my_id`
@@ -335,9 +495,12 @@ class HbAvssBatch():
         logger.debug("[%d] Starting Batch AVSS. Id: %s, Dealer Id: %d, Client Mode: %s",
                      self.my_id, avss_id, dealer_id, client_mode)
 
+        broadcast_msg = None
         dispersal_msg_list = None
         if self.my_id == dealer_id:
-            dispersal_msg_list = self._get_dealer_msg(values)
+            # broadcast_msg: phi & public key for reliable broadcast
+            # dispersal_msg_list: the list of payload z
+            broadcast_msg, dispersal_msg_list = self._get_dealer_msg(values)
 
         # In the client_mode, the dealer is the last node
         n = self.n if not client_mode else self.n+1
@@ -345,18 +508,19 @@ class HbAvssBatch():
         tag = f"{dealer_id}-{avss_id}-B-AVID"
         send, recv = self.get_send(tag), self.subscribe_recv(tag)
 
+        logger.debug("[%d] Starting reliable broadcast", self.my_id)
+        rbc_msg = await reliablebroadcast(
+            tag, self.my_id, n, self.t, dealer_id, broadcast_msg, recv, send)
+
+        logger.debug("[%d] Starting AVID disperse", self.my_id)
         avid = AVID(n, self.t, dealer_id, recv, send, n)
         # start disperse in the background
         self.avid_msg_queue.put_nowait((avid, tag, dispersal_msg_list))
-        # message can be retrieved individually
-        avss_msg = await avid.retrieve(tag, self.my_id)
 
         if client_mode and self.my_id == dealer_id:
             # In client_mode, the dealer is not supposed to do
             # anything after sending the initial value.
             return
 
-        logger.debug("[%d] Dispersal completed.", self.my_id)
-        share = await self._process_avss_msg(avss_id, dealer_id, avss_msg)
-        logger.debug("[%d] Batch AVSS [%s] completed.", self.my_id, avss_id)
-        return share
+        # avss processing
+        await self._process_avss_msg(avss_id, dealer_id, rbc_msg, avid)

--- a/tests/test_hbavss.py
+++ b/tests/test_hbavss.py
@@ -1,11 +1,13 @@
 from pytest import mark
 from random import randint
 from contextlib import ExitStack
+from pickle import dumps
 from honeybadgermpc.polynomial import polynomials_over
 from honeybadgermpc.poly_commit_const import gen_pc_const_crs
 from honeybadgermpc.betterpairing import G1, ZR
 from honeybadgermpc.hbavss import HbAvssLight, HbAvssBatch
 from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.symmetric_crypto import SymmetricCrypto
 import asyncio
 
 
@@ -29,18 +31,158 @@ async def test_hbavss_light(test_router):
 
     value = ZR.random()
     avss_tasks = [None]*n
+    hbavss_list = [None]*n
     dealer_id = randint(0, n-1)
 
     with ExitStack() as stack:
         for i in range(n):
             hbavss = HbAvssLight(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-        shares = await asyncio.gather(*avss_tasks)
+        # shares = await asyncio.gather(*avss_tasks)
+        outputs = await asyncio.gather(
+            *[hbavss_list[i].output_queue.get() for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+    shares = []
+    for item in outputs:
+        shares.append(item[2])
+    assert polynomials_over(ZR).interpolate_at(zip(range(1, n+1), shares)) == value
 
+
+@mark.asyncio
+async def test_hbavss_light_share_fault(test_router):
+    def callback(future):
+        if future.done():
+            ex = future.exception()
+            if ex is not None:
+                print('\nException:', ex)
+                raise ex
+
+    # Injects one invalid share
+    class BadDealer(HbAvssLight):
+        def _get_dealer_msg(self, value):
+            fault_i = randint(0, self.n-1)
+            phi = self.poly.random(self.t, value)
+            commitment, aux_poly = self.poly_commit.commit(phi)
+            ephemeral_secret_key = self.field.random()
+            ephemeral_public_key = pow(self.g, ephemeral_secret_key)
+            z = [None]*self.n
+            for i in range(self.n):
+                witness = self.poly_commit.create_witness(aux_poly, i+1)
+                shared_key = pow(self.public_keys[i], ephemeral_secret_key)
+                if i == fault_i:
+                    z[i] = SymmetricCrypto.encrypt(
+                        str(shared_key).encode(), (ZR.random(), witness))
+                else:
+                    z[i] = SymmetricCrypto.encrypt(
+                        str(shared_key).encode(), (phi(i+1), witness))
+
+            return dumps((commitment, ephemeral_public_key, z))
+
+    t = 2
+    n = 3*t + 1
+
+    g, h, pks, sks = get_avss_params(n, t)
+    sends, recvs, _ = test_router(n)
+    crs = [g, h]
+
+    value = ZR.random()
+    avss_tasks = [None]*n
+    hbavss_list = [None]*n
+    dealer_id = randint(0, n-1)
+
+    with ExitStack() as stack:
+        for i in range(n):
+            if i == dealer_id:
+                hbavss = BadDealer(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            else:
+                hbavss = HbAvssLight(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
+            stack.enter_context(hbavss)
+            if i == dealer_id:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
+                avss_tasks[i].add_done_callback(callback)
+            else:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
+                avss_tasks[i].add_done_callback(callback)
+        outputs = await asyncio.gather(
+            *[hbavss_list[i].output_queue.get() for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+    shares = []
+    for item in outputs:
+        shares.append(item[2])
+    assert polynomials_over(ZR).interpolate_at(zip(range(1, n+1), shares)) == value
+
+
+@mark.asyncio
+async def test_hbavss_light_encryption_fault(test_router):
+    def callback(future):
+        if future.done():
+            ex = future.exception()
+            if ex is not None:
+                print('\nException:', ex)
+                raise ex
+
+    # Injects one undecryptable ciphertext
+    class BadDealer(HbAvssLight):
+        def _get_dealer_msg(self, value):
+            fault_i = randint(0, self.n-1)
+            phi = self.poly.random(self.t, value)
+            commitment, aux_poly = self.poly_commit.commit(phi)
+            ephemeral_secret_key = self.field.random()
+            ephemeral_public_key = pow(self.g, ephemeral_secret_key)
+            z = [None]*self.n
+            for i in range(self.n):
+                witness = self.poly_commit.create_witness(aux_poly, i+1)
+                shared_key = pow(self.public_keys[i], ephemeral_secret_key)
+                if i == fault_i:
+                    z[i] = SymmetricCrypto.encrypt(
+                        str(ZR.random()).encode(), (phi(i+1), witness))
+                else:
+                    z[i] = SymmetricCrypto.encrypt(
+                        str(shared_key).encode(), (phi(i+1), witness))
+
+            return dumps((commitment, ephemeral_public_key, z))
+
+    t = 2
+    n = 3*t + 1
+
+    g, h, pks, sks = get_avss_params(n, t)
+    sends, recvs, _ = test_router(n)
+    crs = [g, h]
+
+    value = ZR.random()
+    avss_tasks = [None]*n
+    hbavss_list = [None]*n
+    dealer_id = randint(0, n-1)
+
+    with ExitStack() as stack:
+        for i in range(n):
+            if i == dealer_id:
+                hbavss = BadDealer(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            else:
+                hbavss = HbAvssLight(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
+            stack.enter_context(hbavss)
+            if i == dealer_id:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
+                avss_tasks[i].add_done_callback(callback)
+            else:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
+                avss_tasks[i].add_done_callback(callback)
+        outputs = await asyncio.gather(
+            *[hbavss_list[i].output_queue.get() for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+    shares = []
+    for item in outputs:
+        shares.append(item[2])
     assert polynomials_over(ZR).interpolate_at(zip(range(1, n+1), shares)) == value
 
 
@@ -54,18 +196,269 @@ async def test_hbavss_batch(test_router):
     crs = gen_pc_const_crs(t, g=g, h=h)
 
     values = [ZR.random()] * (t+1)
-    avss_tasks = [None]*n
+    avss_tasks = [None] * n
     dealer_id = randint(0, n-1)
 
+    shares = [None] * n
     with ExitStack() as stack:
+        hbavss_list = [None] * n
         for i in range(n):
             hbavss = HbAvssBatch(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-        shares = await asyncio.gather(*avss_tasks)
+        shares = await asyncio.gather(*[hbavss_list[i].shares_future for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+
+    fliped_shares = list(map(list, zip(*shares)))
+    recovered_values = []
+    for item in fliped_shares:
+        recovered_values.append(polynomials_over(
+            ZR).interpolate_at(zip(range(1, n+1), item)))
+
+    assert recovered_values == values
+
+
+@mark.asyncio
+async def test_hbavss_batch_share_fault(test_router):
+    def callback(future):
+        if future.done():
+            ex = future.exception()
+            if ex is not None:
+                print('\nException:', ex)
+                raise ex
+
+    # Injects one invalid share
+    class BadDealer(HbAvssBatch):
+        def _get_dealer_msg(self, values):
+            fault_n = randint(1, self.n-1)
+            fault_k = randint(1, len(values)-1)
+            secret_size = len(values)
+            phi = [None] * secret_size
+            commitments = [None] * secret_size
+            aux_poly = [None] * secret_size
+            for k in range(secret_size):
+                phi[k] = self.poly.random(self.t, values[k])
+                commitments[k], aux_poly[k] = self.poly_commit.commit(phi[k])
+
+            ephemeral_secret_key = self.field.random()
+            ephemeral_public_key = pow(self.g, ephemeral_secret_key)
+            dispersal_msg_list = [None] * self.n
+            for i in range(self.n):
+                shared_key = pow(self.public_keys[i], ephemeral_secret_key)
+                z = [None] * secret_size
+                for k in range(secret_size):
+                    witness = self.poly_commit.create_witness(phi[k], aux_poly[k], i+1)
+                    if (i == fault_n and k == fault_k):
+                        z[k] = SymmetricCrypto.encrypt(
+                            str(shared_key).encode("utf-8"),
+                            (ZR.random(), ZR.random(), witness))
+                    else:
+                        z[k] = SymmetricCrypto.encrypt(
+                            str(shared_key).encode("utf-8"),
+                            (phi[k](i+1), aux_poly[k](i+1), witness))
+                dispersal_msg_list[i] = dumps(z)
+            return dumps((commitments, ephemeral_public_key)), dispersal_msg_list
+
+    t = 2
+    n = 3*t + 1
+
+    g, h, pks, sks = get_avss_params(n, t)
+    sends, recvs, _ = test_router(n)
+    crs = gen_pc_const_crs(t, g=g, h=h)
+
+    values = [ZR.random()] * (t+1)
+    avss_tasks = [None] * n
+    dealer_id = randint(0, n-1)
+
+    shares = [None] * n
+    with ExitStack() as stack:
+        hbavss_list = []
+        for i in range(n):
+            if i == dealer_id:
+                hbavss = BadDealer(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            else:
+                hbavss = HbAvssBatch(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list.append(hbavss)
+            stack.enter_context(hbavss)
+            if i == dealer_id:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
+                avss_tasks[i].add_done_callback(callback)
+            else:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
+        for i in range(n):
+            shares[i] = await hbavss_list[i].shares_future
+        for task in avss_tasks:
+            task.cancel()
+
+    fliped_shares = list(map(list, zip(*shares)))
+    recovered_values = []
+    for item in fliped_shares:
+        recovered_values.append(polynomials_over(
+            ZR).interpolate_at(zip(range(1, n+1), item)))
+
+    assert recovered_values == values
+
+
+@mark.asyncio
+# Send t parties entirely faulty messages
+async def test_hbavss_batch_t_share_faults(test_router):
+    def callback(future):
+        if future.done():
+            ex = future.exception()
+            if ex is not None:
+                print('\nException:', ex)
+                raise ex
+
+    class BadDealer(HbAvssBatch):
+        def _get_dealer_msg(self, values):
+            # return super(BadDealer, self)._get_dealer_msg(values)
+            fault_n_list = []
+            while len(fault_n_list) < self.t:
+                i = randint(1, self.n-1)
+                if i not in fault_n_list:
+                    fault_n_list.append(i)
+            secret_size = len(values)
+            phi = [None] * secret_size
+            commitments = [None] * secret_size
+            aux_poly = [None] * secret_size
+            for k in range(secret_size):
+                phi[k] = self.poly.random(self.t, values[k])
+                commitments[k], aux_poly[k] = self.poly_commit.commit(phi[k])
+
+            ephemeral_secret_key = self.field.random()
+            ephemeral_public_key = pow(self.g, ephemeral_secret_key)
+            dispersal_msg_list = [None] * self.n
+            for i in range(self.n):
+                shared_key = pow(self.public_keys[i], ephemeral_secret_key)
+                z = [None] * secret_size
+                for k in range(secret_size):
+                    witness = self.poly_commit.create_witness(phi[k], aux_poly[k], i+1)
+                    if (i in fault_n_list):
+                        z[k] = SymmetricCrypto.encrypt(
+                            str(shared_key).encode("utf-8"),
+                            (ZR.random(), ZR.random(), witness))
+                    else:
+                        z[k] = SymmetricCrypto.encrypt(
+                            str(shared_key).encode("utf-8"),
+                            (phi[k](i+1), aux_poly[k](i+1), witness))
+                dispersal_msg_list[i] = dumps(z)
+            return dumps((commitments, ephemeral_public_key)), dispersal_msg_list
+
+    t = 2
+    n = 3*t + 1
+
+    g, h, pks, sks = get_avss_params(n, t)
+    sends, recvs, _ = test_router(n)
+    crs = gen_pc_const_crs(t, g=g, h=h)
+
+    values = [ZR.random()] * (t+1)
+    avss_tasks = [None] * n
+    dealer_id = randint(0, n-1)
+
+    shares = [None] * n
+    with ExitStack() as stack:
+        hbavss_list = []
+        for i in range(n):
+            if i == dealer_id:
+                hbavss = BadDealer(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            else:
+                hbavss = HbAvssBatch(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list.append(hbavss)
+            stack.enter_context(hbavss)
+            if i == dealer_id:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
+                avss_tasks[i].add_done_callback(callback)
+            else:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
+        for i in range(n):
+            shares[i] = await hbavss_list[i].shares_future
+        for task in avss_tasks:
+            task.cancel()
+
+    fliped_shares = list(map(list, zip(*shares)))
+    recovered_values = []
+    for item in fliped_shares:
+        recovered_values.append(polynomials_over(
+            ZR).interpolate_at(zip(range(1, n+1), item)))
+
+    assert recovered_values == values
+
+
+@mark.asyncio
+async def test_hbavss_batch_encryption_fault(test_router):
+    def callback(future):
+        if future.done():
+            ex = future.exception()
+            if ex is not None:
+                print('\nException:', ex)
+                raise ex
+
+    class BadDealer(HbAvssBatch):
+        def _get_dealer_msg(self, values):
+            fault_n = randint(1, self.n-1)
+            secret_size = len(values)
+            phi = [None] * secret_size
+            commitments = [None] * secret_size
+            aux_poly = [None] * secret_size
+            for k in range(secret_size):
+                phi[k] = self.poly.random(self.t, values[k])
+                commitments[k], aux_poly[k] = self.poly_commit.commit(phi[k])
+
+            ephemeral_secret_key = self.field.random()
+            ephemeral_public_key = pow(self.g, ephemeral_secret_key)
+            dispersal_msg_list = [None] * self.n
+            for i in range(self.n):
+                shared_key = pow(self.public_keys[i], ephemeral_secret_key)
+                z = [None] * secret_size
+                for k in range(secret_size):
+                    witness = self.poly_commit.create_witness(phi[k], aux_poly[k], i+1)
+                    if (i == fault_n):
+                        z[k] = SymmetricCrypto.encrypt(
+                            str(ZR.random()).encode("utf-8"),
+                            (ZR.random(), ZR.random(), witness))
+                    else:
+                        z[k] = SymmetricCrypto.encrypt(
+                            str(shared_key).encode("utf-8"),
+                            (phi[k](i+1), aux_poly[k](i+1), witness))
+                dispersal_msg_list[i] = dumps(z)
+            return dumps((commitments, ephemeral_public_key)), dispersal_msg_list
+
+    t = 2
+    n = 3*t + 1
+
+    g, h, pks, sks = get_avss_params(n, t)
+    sends, recvs, _ = test_router(n)
+    crs = gen_pc_const_crs(t, g=g, h=h)
+
+    values = [ZR.random()] * (t+1)
+    avss_tasks = [None] * n
+    dealer_id = randint(0, n-1)
+
+    shares = [None] * n
+    with ExitStack() as stack:
+        hbavss_list = []
+        for i in range(n):
+            if i == dealer_id:
+                hbavss = BadDealer(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            else:
+                hbavss = HbAvssBatch(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list.append(hbavss)
+            stack.enter_context(hbavss)
+            if i == dealer_id:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
+                avss_tasks[i].add_done_callback(callback)
+            else:
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
+                avss_tasks[i].add_done_callback(callback)
+        for i in range(n):
+            shares[i] = await hbavss_list[i].shares_future
+        for task in avss_tasks:
+            task.cancel()
 
     fliped_shares = list(map(list, zip(*shares)))
     recovered_values = []
@@ -87,6 +480,7 @@ async def test_hbavss_light_client_mode(test_router):
 
     value = ZR.random()
     avss_tasks = [None]*(n+1)
+    hbavss_list = [None]*n
     dealer_id = n
 
     with ExitStack() as stack:
@@ -97,13 +491,17 @@ async def test_hbavss_light_client_mode(test_router):
             client_hbavss.avss(0, value=value, client_mode=True))
         for i in range(n):
             hbavss = HbAvssLight(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
             stack.enter_context(hbavss)
             avss_tasks[i] = asyncio.create_task(
                 hbavss.avss(0, dealer_id=dealer_id, client_mode=True))
-
-        # Ignore the result from the dealer
-        shares = (await asyncio.gather(*avss_tasks))[:-1]
-
+        outputs = await asyncio.gather(
+            *[hbavss_list[i].output_queue.get() for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+    shares = []
+    for item in outputs:
+        shares.append(item[2])
     assert polynomials_over(ZR).interpolate_at(zip(range(1, n+1), shares)) == value
 
 
@@ -116,20 +514,27 @@ async def test_hbavss_light_share_open(test_router):
     sends, recvs, _ = test_router(n)
     crs = [g, h]
 
-    value = int(ZR.random())
+    value = ZR.random()
+    avss_tasks = [None]*n
+    hbavss_list = [None]*n
     dealer_id = randint(0, n-1)
 
     with ExitStack() as stack:
-        avss_tasks = [None]*n
         for i in range(n):
             hbavss = HbAvssLight(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
             else:
-                avss_tasks[i] = asyncio.create_task(
-                    hbavss.avss(0, dealer_id=dealer_id))
-        shares = await asyncio.gather(*avss_tasks)
+                avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
+        outputs = await asyncio.gather(
+            *[hbavss_list[i].output_queue.get() for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+    shares = []
+    for item in outputs:
+        shares.append(item[2])
 
     async def _prog(context):
         share_value = context.field(shares[context.myid])
@@ -142,6 +547,12 @@ async def test_hbavss_light_share_open(test_router):
 
 @mark.asyncio
 async def test_hbavss_light_parallel_share_array_open(test_router):
+    def callback(future):
+        if future.done():
+            ex = future.exception()
+            if ex is not None:
+                print('\nException:', ex)
+                raise ex
     t = 2
     n = 3*t + 1
     k = 4
@@ -155,15 +566,29 @@ async def test_hbavss_light_parallel_share_array_open(test_router):
 
     with ExitStack() as stack:
         avss_tasks = [None]*n
+        hbavss_list = [None]*n
         for i in range(n):
             hbavss = HbAvssLight(pks, sks[i], crs, n, t, i, sends[i], recvs[i])
+            hbavss_list[i] = hbavss
             stack.enter_context(hbavss)
             if i == dealer_id:
                 v, d = values, None
             else:
                 v, d = None, dealer_id
             avss_tasks[i] = asyncio.create_task(hbavss.avss_parallel(0, k, v, d))
-        shares = await asyncio.gather(*avss_tasks)
+            avss_tasks[i].add_done_callback(callback)
+        outputs = [None]*k
+        for j in range(k):
+            outputs[j] = await asyncio.gather(
+                *[hbavss_list[i].output_queue.get() for i in range(n)])
+        for task in avss_tasks:
+            task.cancel()
+
+    shares = [[] for _ in range(n)]
+    for i in range(k):
+        round = outputs[i]
+        for j in range(len(round)):
+            shares[j].append(round[j][2])
 
     async def _prog(context):
         share_values = list(map(context.field, shares[context.myid]))


### PR DESCRIPTION
The implementation of implicate handling part and share recovery part is complete. They are tested separately in the code. The whole structure of the code is changed and it doesn't return a value but set a future value for output instead, as you can see in the code change of the test.

A new method of interpolation on G1 is added to betterpairing.

New tests are also added.