### PR TITLE
remove logging from router.py

### DIFF
--- a/honeybadgermpc/router.py
+++ b/honeybadgermpc/router.py
@@ -1,5 +1,5 @@
 import asyncio
-import logging
+# import logging
 
 
 def simple_router(n):
@@ -12,7 +12,7 @@ def simple_router(n):
 
     def make_send(i):
         def _send(j, o):
-            logging.debug('SEND %8s [%2d -> %2d]' % (o, i, j))
+            # logging.debug('SEND %8s [%2d -> %2d]' % (o, i, j))
             # delay = random.random() * 1.0
             # asyncio.get_event_loop().call_later(delay, mbox[j].put_nowait,(i,o))
             mbox[j].put_nowait((i, o))
@@ -22,7 +22,7 @@ def simple_router(n):
     def make_recv(j):
         async def _recv():
             (i, o) = await mbox[j].get()
-            logging.debug('RECV %8s [%2d -> %2d]' % (o, i, j))
+            # logging.debug('RECV %8s [%2d -> %2d]' % (o, i, j))
             return (i, o)
 
         return _recv


### PR DESCRIPTION
In my experience this is making tests (especially jubjub tests, which are slow) up to 33% faster