### PR TITLE
Encoding/Decoding Optimisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ RUN apt-get update && apt-get install -y \
     libgmp-dev \
     libmpc-dev \
     libmpfr-dev \
-    libntl-dev \
     libflint-dev
+# Download and build NTL from source
+# Shoup recommends not using O3
+RUN wget -qO- https://www.shoup.net/ntl/ntl-11.3.2.tar.gz | tar xzvf - \
+         &&  cd ntl-11.3.2/src \
+         && ./configure CXXFLAGS="-g -O2 -fPIC -march=native -pthread -std=c++11" \
+         && make -j4 \
+         && make install
 
 # Sets default directory for running the rest of the commands
 WORKDIR /usr/src/HoneyBadgerMPC

--- a/honeybadgermpc/batch_reconstruction.py
+++ b/honeybadgermpc/batch_reconstruction.py
@@ -145,8 +145,9 @@ async def batch_reconstruct(secret_shares, p, t, n, myid, send, recv, config=Non
     data_r2 = [asyncio.create_task(recv()) for recv in q_r2]
     del subscribe  # ILC should determine we can garbage collect after this
 
-    enc = EncoderFactory.get(point, Algorithm.FFT if use_fft else Algorithm.VANDERMONDE)
-    dec = DecoderFactory.get(point, Algorithm.FFT if use_fft else Algorithm.VANDERMONDE)
+    enc = EncoderFactory.get(point)
+    dec = DecoderFactory.get(point)
+
     decoding_algorithm = Algorithm.GAO
     if config is not None:
         decoding_algorithm = config.decoding_algorithm

--- a/honeybadgermpc/ntl/README.md
+++ b/honeybadgermpc/ntl/README.md
@@ -1,0 +1,55 @@
+# Python-NTL interface
+
+The code in this directory exposes an python interface
+for several NTL functions, and other C++ code using
+NTL.
+
+# Modifying code
+
+Currently, this directory is not mounted when you run
+`docker-compose ...`. In order to mount it, please remove
+or comment out this line `- /usr/src/HoneyBadgerMPC/honeybadgermpc/ntl`
+ and then start the container again.
+
+
+# Building code
+
+If you go through the instructions above, you will find that you might
+need to rebuild all the Cython code. This can be done by running the
+following command from `/usr/src/HoneyBadgerMPC`
+
+
+```python setup.py build_ext --inplace```
+
+
+The same command can be used to rebuild the code if you
+modify any of the Cython node. Note that you *must* rebuild the code
+to observe any changes during execution.
+
+# Writing Parallel Code
+
+Take a look at NTL documentation and see which operations are already
+parallelized. In general, it might be better to use these directly
+whenever possible.
+
+If you wish to write parallel code yourself, please take a look
+at OpenMP documentation for Cython.
+
+Here's a gist of what parallel code using OpenMP in Cython would look
+like when using NTL
+
+```
+with nogil, parallel():
+    ZZ_p::init(modulus)
+    for i in prange(start, end, step):
+        ...:
+```
+
+The operation above starts `n` threads (`n` is decided by OpenMP and
+can be modified by using `openmp.set_num_threads` or modifying the
+environment variable `OMP_NUM_THREADS`), calls
+`ZZ_p::init()` for each thread, and then splits the
+`for` loop into `n` chunks. Different chunking strategies
+can be used but this has not been explored much and might not
+particularly turn out to be useful since we have a largely even
+distribution of work among threads.

--- a/honeybadgermpc/ntl/ctypes.pxd
+++ b/honeybadgermpc/ntl/ctypes.pxd
@@ -1,23 +1,24 @@
 from libcpp.vector cimport vector
 
 cdef extern from "ntlwrapper.h":
-    cdef cppclass ZZ_c "ZZ":
+    cdef cppclass ZZ "ZZ":
+        ZZ() except +
         pass
 
     cdef cppclass ZZ_pContext_c "ZZ_pContext":
         void restore()
         pass
 
-    cdef cppclass ZZ_p_c "ZZ_p":
-        pass
+    cdef cppclass ZZ_p "ZZ_p":
+        ZZ_p() except +
 
     cdef cppclass ZZ_pX_c "ZZ_pX":
         void SetMaxLength(size_t)
         pass
 
     cdef cppclass vec_ZZ_p:
-        ZZ_p_c& operator[](size_t)
-        void SetLength(int n)
+        ZZ_p& operator[](size_t)
+        void SetLength(int n) nogil
         void kill()
         size_t length()
     cdef cppclass mat_ZZ_p:
@@ -25,17 +26,18 @@ cdef extern from "ntlwrapper.h":
         vec_ZZ_p& operator[](size_t)
         void kill()
 
-    void ZZ_p_init "ZZ_p::init"(ZZ_c x)
-    void SetNumThreads(int n)
-    void ZZ_conv_from_int "conv"(ZZ_c x, int i)
-    void ZZ_p_conv_from_int "conv"(ZZ_p_c x, int i)
-    void ZZ_conv_to_int "conv"(int i, ZZ_c x)
-    void ZZ_conv_from_long "conv"(ZZ_c x, long l)
-    void ZZ_conv_to_long "conv"(long l, ZZ_c x)
+
+    void ZZ_p_init "ZZ_p::init"(ZZ x) nogil
+    void SetNTLNumThreads_c "SetNumThreads"(int n)
     void mat_ZZ_p_mul "mul"(mat_ZZ_p x, mat_ZZ_p a, mat_ZZ_p b)
     void mat_ZZ_p_mul_vec "mul"(vec_ZZ_p x, mat_ZZ_p a, vec_ZZ_p b) nogil
-    void ZZ_pX_get_coeff "GetCoeff"(ZZ_p_c r, ZZ_pX_c x, int i)
-    void ZZ_pX_set_coeff "SetCoeff"(ZZ_pX_c x, int i, ZZ_p_c a)
-    void ZZ_pX_eval "eval" (ZZ_p_c b, ZZ_pX_c f, ZZ_p_c a)
-    void SqrRootMod "SqrRootMod"(ZZ_c x, ZZ_c a, ZZ_c n)
+    void ZZ_pX_get_coeff "GetCoeff"(ZZ_p r, ZZ_pX_c x, int i)
+    void ZZ_pX_set_coeff "SetCoeff"(ZZ_pX_c x, int i, ZZ_p a)
+    void ZZ_pX_eval "eval" (ZZ_p b, ZZ_pX_c f, ZZ_p a)
+    void SqrRootMod "SqrRootMod"(ZZ x, ZZ a, ZZ n)
     int AvailableThreads()
+    ZZ ZZFromBytes(const unsigned char*, long)
+    unsigned char* bytesFromZZ(ZZ x)
+    ZZ_p to_ZZ_p(ZZ)
+    ZZ to_ZZ "rep"(ZZ_p)
+    int ZZNumBytes "NumBytes"(ZZ)

--- a/honeybadgermpc/ntl/helpers.pxd
+++ b/honeybadgermpc/ntl/helpers.pxd
@@ -1,21 +1,24 @@
-from .ctypes cimport ZZ_c, mat_ZZ_p, vec_ZZ_p, ZZ_p_c, ZZ_pX_c
+from .ctypes cimport ZZ, mat_ZZ_p, vec_ZZ_p, ZZ_p, ZZ_pX_c
 from libcpp.vector cimport vector
 from libcpp cimport bool
 
 cdef extern from "rsdecode_impl.h":
-    cdef void interpolate_c "interpolate"(vector[ZZ_c] r, vector[ZZ_c] x,
-                                          vector[ZZ_c] y, ZZ_c modulus)
-    cdef bool vandermonde_inverse_c "vandermonde_inverse"(mat_ZZ_p r, vector[ZZ_c] x,
-                                                          ZZ_c modulus)
+    cdef void interpolate_c "interpolate"(vector[ZZ] r, vector[ZZ] x,
+                                          vector[ZZ] y, ZZ modulus)
+    cdef bool vandermonde_inverse_c "vandermonde_inverse"(mat_ZZ_p r, vector[ZZ] x,
+                                                          ZZ modulus)
     cdef void set_vm_matrix_c "set_vm_matrix"(mat_ZZ_p r, vec_ZZ_p x_list,
-                                              int d, ZZ_c modulus)
-    cdef void fft_c "fft"(vec_ZZ_p r, vec_ZZ_p coeffs, ZZ_p_c omega, int n)
+                                              int d)
+    cdef void fft_c "fft"(vec_ZZ_p r, vec_ZZ_p coeffs, ZZ_p omega, int n)
+    cdef void fft_partial_c "fft"(vec_ZZ_p r, vec_ZZ_p coeffs, ZZ_p omega,
+                                  int n, int k) nogil
     cdef void fnt_decode_step1_c "fnt_decode_step1"(ZZ_pX_c A_coeffs,
                                                     vec_ZZ_p Ad_evals,
-                                                    vector[int] z, ZZ_p_c omega, int n)
+                                                    vector[int] z,
+                                                    ZZ_p omega, int n)
     cdef void fnt_decode_step2_c "fnt_decode_step2"(vec_ZZ_p P_coeffs, ZZ_pX_c A_coeffs,
                                                     vec_ZZ_p Ad_evals, vector[int] z,
-                                                    vec_ZZ_p ys, ZZ_p_c omega,
+                                                    vec_ZZ_p ys, ZZ_p omega,
                                                     int n) nogil
     cdef bool gao_interpolate_c "gao_interpolate"(vec_ZZ_p res_vec, vec_ZZ_p err_vec,
                                                   vec_ZZ_p x_vec,
@@ -25,5 +28,5 @@ cdef extern from "rsdecode_impl.h":
                                                           vec_ZZ_p x_vec,
                                                           vector[int] z,
                                                           vec_ZZ_p y_vec,
-                                                          ZZ_p_c omega,
+                                                          ZZ_p omega,
                                                           int k, int n, int order)

--- a/honeybadgermpc/ntl/helpers.pyx
+++ b/honeybadgermpc/ntl/helpers.pyx
@@ -3,20 +3,38 @@
 # The data validation and checking must be done in python in all cases!
 # PEP8 standards are observed wherever possible but ignored in cases whether NTL
 # classes are used (like ZZ, mat_ZZ_p, etc) and also for NTL function names
-from .ctypes cimport ZZ_c, ZZ_p_c, mat_ZZ_p, vec_ZZ_p, ZZ_pX_c
-from .ctypes cimport ZZ_p_conv_from_int, mat_ZZ_p_mul, ZZ_conv_from_int
+from .ctypes cimport ZZ, ZZ_p, mat_ZZ_p, vec_ZZ_p, ZZ_pX_c
+from .ctypes cimport mat_ZZ_p_mul
+from .ctypes cimport ZZFromBytes, bytesFromZZ, to_ZZ_p, to_ZZ, ZZNumBytes
 from .objectwrapper cimport ccrepr, ccreadstr
-from .ctypes cimport SetNumThreads, AvailableThreads, ZZ_p_init, ZZ_pX_get_coeff, \
+from .ctypes cimport SetNTLNumThreads_c, AvailableThreads, ZZ_p_init, ZZ_pX_get_coeff, \
     ZZ_pX_set_coeff, ZZ_pX_eval, SqrRootMod
 from cpython.int cimport PyInt_AS_LONG
+from cython.parallel import parallel, prange
+from libc.stdlib cimport free
+cimport openmp
 
-cdef ZZ_c py_obj_to_ZZ(object v):
-    cdef ZZ_c result
+cdef ZZ intToZZ(x):
+    num = (x.bit_length() + 7) // 8
+    return ZZFromBytes(x.to_bytes(num, 'little'), num)
+
+cdef ZZToInt(ZZ X):
+    cdef int n = ZZNumBytes(X)
+    cdef unsigned char*b = bytesFromZZ(X)
+    result = int.from_bytes(b[:n], 'little')
+    free(b)
+    return result
+
+cdef ZZ_p intToZZp(x):
+    return to_ZZ_p(intToZZ(x))
+
+cdef ZZpToInt(ZZ_p X):
+    return ZZToInt(to_ZZ(X))
+
+cdef ZZ py_obj_to_ZZ(object v):
+    cdef ZZ result
     if isinstance(v, int):
-        if v <= 2147483647:
-            ZZ_conv_from_int(result, PyInt_AS_LONG(v))
-        else:
-            ccreadstr(result, str(v))
+        result = intToZZ(v)
     elif v is not None:
         ccreadstr(result, v)
     else:
@@ -24,13 +42,10 @@ cdef ZZ_c py_obj_to_ZZ(object v):
 
     return result
 
-cdef ZZ_p_c py_obj_to_ZZ_p(object v):
-    cdef ZZ_p_c result
+cdef ZZ_p py_obj_to_ZZ_p(object v):
+    cdef ZZ_p result
     if isinstance(v, int):
-        if v <= 2147483647:
-            ZZ_p_conv_from_int(result, PyInt_AS_LONG(v))
-        else:
-            ccreadstr(result, str(v))
+        result = intToZZp(v)
     elif v is not None:
         ccreadstr(result, v)
     else:
@@ -46,10 +61,10 @@ cdef vec_ZZ_p py_list_to_vec_ZZ_p(object v):
     result.SetLength(len(v))
     cdef int i
     for i in range(len(v)):
-        result[i] = py_obj_to_ZZ_p(v[i])
+        result[i] = intToZZp(v[i])
     return result
 
-cdef str ZZ_to_str(ZZ_c x):
+cdef str ZZ_to_str(ZZ x):
     return ccrepr(x)
 
 cpdef lagrange_interpolate(x, y, modulus):
@@ -64,15 +79,15 @@ cpdef lagrange_interpolate(x, y, modulus):
     """
     assert len(x) == len(y)
 
-    cdef vector[ZZ_c] x_vec;
-    cdef vector[ZZ_c] y_vec;
-    cdef vector[ZZ_c] r_vec;
+    cdef vector[ZZ] x_vec;
+    cdef vector[ZZ] y_vec;
+    cdef vector[ZZ] r_vec;
 
     for i in range(len(x)):
         x_vec.push_back(py_obj_to_ZZ(x[i]))
         y_vec.push_back(py_obj_to_ZZ(y[i]))
 
-    cdef ZZ_c zz_modulus = py_obj_to_ZZ(modulus)
+    cdef ZZ zz_modulus = py_obj_to_ZZ(modulus)
     interpolate_c(r_vec, x_vec, y_vec, zz_modulus)
 
     result = []
@@ -83,15 +98,15 @@ cpdef lagrange_interpolate(x, y, modulus):
 cpdef evaluate(polynomial, x, modulus):
     """Evaluate polynomial at x"""
     cdef ZZ_pX_c poly
-    cdef ZZ_p_c y
+    cdef ZZ_p y
     cdef int i
 
     ZZ_p_init(py_obj_to_ZZ(modulus))
     poly.SetMaxLength(len(polynomial))
     for i in range(len(polynomial)):
-        ZZ_pX_set_coeff(poly, i, py_obj_to_ZZ_p(polynomial[i]))
+        ZZ_pX_set_coeff(poly, i, intToZZp(polynomial[i]))
 
-    ZZ_pX_eval(y, poly, py_obj_to_ZZ_p(x))
+    ZZ_pX_eval(y, poly, intToZZp(x))
     return int(ccrepr(y))
 
 cpdef vandermonde_inverse(x, modulus):
@@ -102,12 +117,12 @@ cpdef vandermonde_inverse(x, modulus):
     :type modulus: integers
     :return:
     """
-    cdef vector[ZZ_c] x_vec;
+    cdef vector[ZZ] x_vec;
 
     for xi in x:
         x_vec.push_back(py_obj_to_ZZ(xi))
 
-    cdef ZZ_c zz_modulus = py_obj_to_ZZ(modulus)
+    cdef ZZ zz_modulus = py_obj_to_ZZ(modulus)
     cdef mat_ZZ_p r
     vandermonde_inverse_c(r, x_vec, zz_modulus)
 
@@ -139,12 +154,12 @@ cpdef vandermonde_batch_interpolate(x, data_list, modulus):
     :type modulus: integer
     :return:
     """
-    cdef vector[ZZ_c] x_vec;
+    cdef vector[ZZ] x_vec;
 
     for xi in x:
         x_vec.push_back(py_obj_to_ZZ(xi))
 
-    cdef ZZ_c zz_modulus = py_obj_to_ZZ(modulus)
+    cdef ZZ zz_modulus = py_obj_to_ZZ(modulus)
     cdef mat_ZZ_p r
     d = vandermonde_inverse_c(r, x_vec, zz_modulus)
     if d is False:
@@ -158,16 +173,21 @@ cpdef vandermonde_batch_interpolate(x, data_list, modulus):
     for i in range(n_chunks):
         l = len(data_list[i])
         for j in range(l):
-            m[j][i] = py_obj_to_ZZ_p(data_list[i][j])
+            m[j][i] = intToZZp(data_list[i][j])
         for j in range(l, k):
-            m[j][i] = py_obj_to_ZZ_p(0)
+            m[j][i] = intToZZp(0)
     cdef mat_ZZ_p reconstructions
     mat_ZZ_p_mul(reconstructions, r, m)
 
     polynomials = [[None] * k for _ in range(n_chunks)]
+
     for i in range(n_chunks):
         for j in range(k):
-            polynomials[i][j] = int(ccrepr(reconstructions[j][i]))
+            polynomials[i][j] = 0
+
+    for i in range(n_chunks):
+        for j in range(k):
+            polynomials[i][j] = ZZpToInt(reconstructions[j][i])
     reconstructions.kill()
     m.kill()
     r.kill()
@@ -193,21 +213,21 @@ cpdef vandermonde_batch_evaluate(x, polynomials, modulus):
     # Degree of polynomial. Actually number of coefficients.
     cdef int d = max([len(poly) for poly in polynomials])
 
-    cdef ZZ_c zz_modulus = py_obj_to_ZZ(modulus)
+    cdef ZZ zz_modulus = py_obj_to_ZZ(modulus)
     ZZ_p_init(zz_modulus)
 
     # Set vm_matrix
     cdef vec_ZZ_p x_vec = py_list_to_vec_ZZ_p(x)
-    set_vm_matrix_c(vm_matrix, x_vec, d, zz_modulus)
+    set_vm_matrix_c(vm_matrix, x_vec, d)
 
     # Set matrix with polynomial coefficients
     poly_matrix.SetDims(d, k)
     for i in range(k):
         l = len(polynomials[i])
         for j in range(l):
-            poly_matrix[j][i] = py_obj_to_ZZ_p(polynomials[i][j])
+            poly_matrix[j][i] = intToZZp(polynomials[i][j])
         for j in range(l, d):
-            poly_matrix[j][i] = py_obj_to_ZZ_p(0)
+            poly_matrix[j][i] = intToZZp(0)
 
     # Finally multiply matrices. This gives evaluation of polynomials at
     # all points chosen
@@ -217,26 +237,78 @@ cpdef vandermonde_batch_evaluate(x, polynomials, modulus):
     result = [[None] * n for _ in range(k)]
     for i in range(n):
         for j in range(k):
-            result[j][i] = int(ccrepr(res_matrix[i][j]))
+            result[j][i] = ZZpToInt(res_matrix[i][j])
     return result
 
 cpdef fft(coeffs, omega, modulus, int n):
     cdef int i, d;
     cdef vec_ZZ_p coeffs_vec, result_vec;
 
-    ZZ_p_init(py_obj_to_ZZ(modulus))
+    ZZ_p_init(intToZZ(modulus))
 
     d = len(coeffs)
     coeffs_vec.SetLength(d)
     for i in range(d):
-        coeffs_vec[i] = py_obj_to_ZZ_p(coeffs[i])
+        coeffs_vec[i] = intToZZp(coeffs[i])
 
-    cdef ZZ_p_c zz_omega = py_obj_to_ZZ_p(omega)
+    cdef ZZ_p zz_omega = intToZZp(omega)
     fft_c(result_vec, coeffs_vec, zz_omega, n)
 
     result = [None] * n
     for i in range(n):
-        result[i] = int(ccrepr(result_vec[i]))
+        result[i] = ZZpToInt(result_vec[i])
+
+    return result
+
+cpdef partial_fft(coeffs, omega, modulus, int n, int k):
+    cdef int i, d;
+    cdef vec_ZZ_p coeffs_vec, result_vec;
+
+    ZZ_p_init(intToZZ(modulus))
+
+    d = len(coeffs)
+    coeffs_vec.SetLength(d)
+    for i in range(d):
+        coeffs_vec[i] = intToZZp(coeffs[i])
+
+    cdef ZZ_p zz_omega = intToZZp(omega)
+    fft_partial_c(result_vec, coeffs_vec, zz_omega, n, k)
+
+    result = [None] * k
+    for i in range(k):
+        result[i] = ZZpToInt(result_vec[i])
+
+    return result
+
+cpdef fft_batch_evaluate(coeffs, omega, modulus, int n, int k):
+    cdef int i, d;
+    cdef vector[vec_ZZ_p] coeffs_vec_list, result_vec_list
+    cdef ZZ zz_modulus
+
+    zz_modulus = intToZZ(modulus)
+    ZZ_p_init(zz_modulus)
+
+    batch_size = len(coeffs)
+    d = len(coeffs[0])
+
+    coeffs_vec_list.resize(batch_size)
+    result_vec_list.resize(batch_size)
+
+    for i in range(batch_size):
+        coeffs_vec_list[i].SetLength(d)
+        for j in range(d):
+            coeffs_vec_list[i][j] = intToZZp(coeffs[i][j])
+
+    cdef ZZ_p zz_omega = intToZZp(omega)
+    with nogil, parallel():
+        ZZ_p_init(zz_modulus)
+        for i in prange(batch_size):
+            fft_partial_c(result_vec_list[i], coeffs_vec_list[i], zz_omega, n, k)
+
+    result = [[None] * k for _ in range(batch_size)]
+    for i in range(batch_size):
+        for j in range(k):
+            result[i][j] = ZZpToInt(result_vec_list[i][j])
 
     return result
 
@@ -246,15 +318,15 @@ def fft_interpolate(zs, ys, omega, modulus, int n):
     cdef vector[int] z_vec;
     cdef vec_ZZ_p y_vec, Ad_evals_vec, P_coeffs
     cdef ZZ_pX_c A
-    cdef ZZ_p_c zz_omega
+    cdef ZZ_p zz_omega
 
-    ZZ_p_init(py_obj_to_ZZ(modulus))
-    zz_omega = py_obj_to_ZZ_p(omega)
+    ZZ_p_init(intToZZ(modulus))
+    zz_omega = intToZZp(omega)
     z_vec.resize(k)
     y_vec.SetLength(k)
     for i in range(k):
         z_vec[i] = PyInt_AS_LONG(zs[i])
-        y_vec[i] = py_obj_to_ZZ_p(ys[i])
+        y_vec[i] = intToZZp(ys[i])
 
     fnt_decode_step1_c(A, Ad_evals_vec, z_vec, zz_omega, n)
     fnt_decode_step2_c(P_coeffs, A, Ad_evals_vec, z_vec, y_vec, zz_omega, n)
@@ -270,11 +342,12 @@ def fft_batch_interpolate(zs, ys_list, omega, modulus, int n):
     cdef vector[int] z_vec;
     cdef vec_ZZ_p y_vec, Ad_evals_vec, P_coeffs
     cdef ZZ_pX_c A
-    cdef ZZ_p_c zz_omega
+    cdef ZZ_p zz_omega
     cdef int n_chunks = len(ys_list)
-
-    ZZ_p_init(py_obj_to_ZZ(modulus))
-    zz_omega = py_obj_to_ZZ_p(omega)
+    cdef ZZ zz_modulus
+    zz_modulus = intToZZ(modulus)
+    ZZ_p_init(intToZZ(modulus))
+    zz_omega = intToZZp(omega)
     z_vec.resize(k)
     for i in range(k):
         z_vec[i] = PyInt_AS_LONG(zs[i])
@@ -288,22 +361,23 @@ def fft_batch_interpolate(zs, ys_list, omega, modulus, int n):
     for i in range(n_chunks):
         y_vec_list[i].SetLength(k)
         for j in range(k):
-            y_vec_list[i][j] = py_obj_to_ZZ_p(ys_list[i][j])
+            y_vec_list[i][j] = intToZZp(ys_list[i][j])
 
-    for i in range(n_chunks):
-        fnt_decode_step2_c(result_vec_list[i], A, Ad_evals_vec, z_vec, y_vec_list[i],
-                           zz_omega, n)
+    with nogil, parallel():
 
+        ZZ_p_init(zz_modulus)
+        for i in prange(n_chunks):
+            fnt_decode_step2_c(result_vec_list[i], A, Ad_evals_vec, z_vec, y_vec_list[i],
+                               zz_omega, n)
     result = [[None] * k for _ in range(n_chunks)]
     for i in range(n_chunks):
         for j in range(k):
-            result[i][j] = int(ccrepr(result_vec_list[i][j]))
+            result[i][j] = ZZpToInt(result_vec_list[i][j])
 
     return result
 
-cpdef SetNTLNumThreads(x):
-    x = int(x)
-    SetNumThreads(x)
+cpdef SetNTLNumThreads(int x):
+    SetNTLNumThreads_c(x)
 
 cpdef int AvailableNTLThreads():
     return AvailableThreads()
@@ -311,12 +385,12 @@ cpdef int AvailableNTLThreads():
 cpdef gao_interpolate(x, y, int k, modulus, z=None, omega=None, order=None,
                       use_fft=False):
     cdef vec_ZZ_p x_vec, y_vec, res_vec, err_vec
-    cdef ZZ_p_c zz_omega
+    cdef ZZ_p zz_omega
     cdef vector[int] z_vec;
     cdef int i, n, int_order
     cdef int success
     assert len(x) == len(y)
-    ZZ_p_init(py_obj_to_ZZ(modulus))
+    ZZ_p_init(intToZZ(modulus))
 
     is_null = [yi is None for yi in y]
     x = [x[i] for i in range(len(x)) if not is_null[i]]
@@ -329,15 +403,15 @@ cpdef gao_interpolate(x, y, int k, modulus, z=None, omega=None, order=None,
     y_vec.SetLength(n)
 
     for i in range(n):
-        x_vec[i] = py_obj_to_ZZ_p(x[i])
-        y_vec[i] = py_obj_to_ZZ_p(y[i])
+        x_vec[i] = intToZZp(x[i])
+        y_vec[i] = intToZZp(y[i])
 
     if use_fft is True:
         assert z is not None
         assert len(z) is n
         assert omega is not None
 
-        zz_omega = py_obj_to_ZZ_p(omega)
+        zz_omega = intToZZp(omega)
         int_order = int(order)
         z_vec.resize(n)
         for i in range(n):
@@ -361,6 +435,17 @@ cpdef gao_interpolate(x, y, int k, modulus, z=None, omega=None, order=None,
     return None, None
 
 def sqrt_mod(a, n):
-    cdef ZZ_c x
-    SqrRootMod(x, py_obj_to_ZZ(a), py_obj_to_ZZ(n))
+    cdef ZZ x
+    SqrRootMod(x, intToZZ(a), intToZZ(n))
     return int(ccrepr(x))
+
+cpdef SetNumThreads(int n):
+    """
+    Set threads for both NTL and OpenMP
+    :param n: Number of threads
+    """
+    SetNTLNumThreads(n)
+    openmp.omp_set_num_threads(n)
+
+cpdef GetMaxThreads():
+    return openmp.omp_get_max_threads()

--- a/honeybadgermpc/ntl/ntlwrapper.h
+++ b/honeybadgermpc/ntl/ntlwrapper.h
@@ -6,4 +6,11 @@
 #include <NTL/mat_ZZ_p.h>
 #include <NTL/BasicThreadPool.h>
 using namespace NTL;
+
+unsigned char* bytesFromZZ(const ZZ& a) {
+   long n = NumBytes(a);
+   unsigned char* p = new unsigned char[n];
+   BytesFromZZ(p, a, n);
+   return p;
+}
 #endif

--- a/honeybadgermpc/ntl/rsdecode_impl.h
+++ b/honeybadgermpc/ntl/rsdecode_impl.h
@@ -4,9 +4,64 @@
 #include <NTL/vec_ZZ_p.h>
 #include <vector>
 #include <iostream>
+#include <map>
+#include <omp.h>
 
 using namespace NTL;
 using namespace std;
+
+// Threshold to decide when to use Vandermonde in _fft
+// Determined experimentally based on minimising time taken by fft
+#define FFT_VAN_THRESHOLD 16
+
+map <pair<int, ZZ>, mat_ZZ_p> _fft_van_matrices;
+ZZ _fft_van_modulus;
+mutex _interp_mutex;
+
+
+void set_vm_matrix(mat_ZZ_p &result, vec_ZZ_p &x_list, int d)
+{
+    int n = x_list.length();
+
+    result.SetDims(n, d);
+    for (int i=0; i < n; i++) {
+        ZZ_p x(1);
+        ZZ_p x_here = x_list[i];
+        for (int j=0; j < d; j++) {
+            result[i][j] = x;
+            x = x * x_here;
+        }
+    }
+}
+
+void _set_fft_vandermonde_matrix(ZZ_p omega, int n)
+{
+    vec_ZZ_p x;
+    x.SetLength(n);
+    set(x[0]);
+    for (int i=1; i < n; i++) {
+        mul(x[i], x[i-1], omega);
+    }
+    mat_ZZ_p interpolator;
+    set_vm_matrix(interpolator, x, n);
+
+    _fft_van_matrices.emplace(make_pair(make_pair(n, rep(omega)), interpolator));
+}
+
+mat_ZZ_p& get_fft_vandermonde_matrix(ZZ_p omega, int n)
+{
+    lock_guard<mutex> lock(_interp_mutex);
+    if (ZZ_p::modulus() != _fft_van_modulus) {
+        _fft_van_modulus = ZZ_p::modulus();
+        _fft_van_matrices.clear();
+    }
+
+    if (_fft_van_matrices.find(make_pair(n, rep(omega))) == _fft_van_matrices.end()) {
+        _set_fft_vandermonde_matrix(omega, n);
+    }
+
+    return (_fft_van_matrices.find(make_pair(n, rep(omega))))->second;
+}
 
 void interpolate(vector<ZZ> &result, vector<ZZ> &x, vector<ZZ> &y, ZZ &modulus)
 {
@@ -65,76 +120,74 @@ bool vandermonde_inverse(mat_ZZ_p &result, vector<ZZ> &x, ZZ &modulus)
     return !IsZero(det);
 }
 
-void set_vm_matrix(mat_ZZ_p &result, vec_ZZ_p &x_list, int d, ZZ &modulus)
-{
-    ZZ_p::init(modulus);
-    int n = x_list.length();
 
-    result.SetDims(n, d);
-    for (int i=0; i < n; i++) {
-        ZZ_p x(1);
-        ZZ_p x_here = x_list[i];
-        for (int j=0; j < d; j++) {
-            result[i][j] = x;
-            x = x * x_here;
-        }
-    }
-}
+void _fft(vec_ZZ_p &a, ZZ_p omega, int n, int m=-1,
+          mat_ZZ_p *van_matrix=NULL, int van_threshold=-1) {
+    m = (m == -1) ? n : m;
 
-void _fft(ZZ_p *a, ZZ_p *tmp, ZZ_p omega, int n) {
     if (n == 1) {
         return;
     }
 
-    for (int i=0; i < n; i++) {
-        tmp[i] = a[i];
+    if (van_matrix != NULL && van_threshold == n) {
+        mul(a, *van_matrix, a);
+        return;
     }
 
-    ZZ_p *a0 = a, *a1 = a + n / 2;
+    vec_ZZ_p a0, a1;
+    a0.SetLength(n / 2);
+    a1.SetLength(n / 2);
+
     for (int k=0; k < n / 2; k++) {
-        a0[k] = tmp[2 * k];
-        a1[k] = tmp[2 * k + 1];
+        a0[k] = a[2 * k];
+        a1[k] = a[2 * k + 1];
     }
 
-    ZZ_p omega2 = omega * omega;
+    ZZ_p omega2;
+    mul(omega2, omega, omega);
 
-    _fft(a0, tmp, omega2, n / 2);
-    _fft(a1, tmp + n / 2, omega2, n / 2);
+    _fft(a0, omega2, n / 2, m, van_matrix, van_threshold);
+    _fft(a1, omega2, n / 2, m, van_matrix, van_threshold);
 
-    for (int i=0; i < n; i++) {
-        tmp[i] = a[i];
-    }
+    ZZ_p w;
+    set(w);
 
-    ZZ_p w(1);
-    ZZ_p *t0 = tmp, *t1 = tmp + n / 2;
+    int lim = (m + 1) / 2;
+    ZZ_p t2;
 
     for (unsigned int k=0; k < n / 2; k++) {
-        a[k] = t0[k] +  w * t1[k];
-        a[k + n / 2] = t0[k] - w * t1[k];
-        w = w * omega;
+        mul(t2, w, a1[k]);
+        if (k < m) {
+            add(a[k], a0[k], t2);
+        }
+        if (k + n / 2 < m) {
+            sub(a[k + n / 2], a0[k], t2);
+        }
+        mul(w, w, omega);
     }
 }
 
-void fft(vec_ZZ_p &result, vec_ZZ_p &coeffs, ZZ_p &omega, int n) {
-    ZZ_p *a = new ZZ_p[n];
-    ZZ_p *tmp = new ZZ_p[n];
-
+void fft(vec_ZZ_p &a, vec_ZZ_p &coeffs, ZZ_p &omega, int n, int k=-1) {
+    a.SetLength(n);
     for (unsigned int i=0; i < coeffs.length() && i < n; i++) {
         a[i] = coeffs[i];
     }
     for (int i=coeffs.length(); i < n; i++) {
-        a[i] = ZZ_p(0);
+        clear(a[i]);
     }
 
-    _fft(a, tmp, omega, n);
-
-    result.SetLength(n);
-    for (int i=0; i < n; i++) {
-        result[i] = a[i];
+    mat_ZZ_p *van_matrix=NULL;
+    int van_threshold = FFT_VAN_THRESHOLD;
+    if (n >= van_threshold) {
+        ZZ_p omega_pow;
+        power(omega_pow, omega, n / van_threshold);
+        van_matrix = &get_fft_vandermonde_matrix(omega_pow, van_threshold);
     }
 
-    delete[] tmp;
-    delete[] a;
+    _fft(a, omega, n, k, van_matrix, van_threshold);
+    if (k != -1) {
+        a.SetLength(k);
+    }
 }
 
 void fnt_decode_step1(ZZ_pX &A, vec_ZZ_p &Ad_evals, vector<int>& zs,
@@ -184,30 +237,30 @@ void fnt_decode_step2(vec_ZZ_p &P_coeffs, ZZ_pX &A, vec_ZZ_p &Ad_evals,
     vec_ZZ_p N_coeffs;
     N_coeffs.SetLength(n);
     for (int i=0; i < n; i++) {
-       N_coeffs[i] = 0;
+       clear(N_coeffs[i]);
     }
 
     for (int i=0; i < k; i++) {
-        N_coeffs[zs[i]] = nis[i];
+        swap(N_coeffs[zs[i]], nis[i]);
     }
 
     // Build Q = P / A
     vec_ZZ_p N_rev_evals;
-    fft(N_rev_evals, N_coeffs, omega, n);
+    ZZ_p omega_inv;
+    inv(omega_inv, omega);
+
+    fft(N_rev_evals, N_coeffs, omega_inv, n, (k < n) ? k + 1: n);
 
     ZZ_pX Q;
-    Q.SetMaxLength(n);
-    for (int i=0; i < n; i++) {
-        SetCoeff(Q, i, -N_rev_evals[n - i - 1]);
+    Q.SetMaxLength(k);
+    for (int i=0; i < k; i++) {
+        SetCoeff(Q, i, -N_rev_evals[(i + 1) % n]);
     }
 
     ZZ_pX P;
     mul(P, Q, A);
 
-    P_coeffs.SetLength(k);
-    for (int i=0; i < k; i++) {
-        P_coeffs[i] = coeff(P, i);
-    }
+    VectorCopy(P_coeffs, P, k);
 }
 
 // This combines fnt_decode steps 1 and step 2

--- a/tests/test_reed_solomon.py
+++ b/tests/test_reed_solomon.py
@@ -2,6 +2,10 @@ import pytest
 from honeybadgermpc.reed_solomon import VandermondeEncoder, FFTEncoder, \
     VandermondeDecoder, FFTDecoder, GaoRobustDecoder, WelchBerlekampRobustDecoder
 from honeybadgermpc.polynomial import EvalPoint
+from honeybadgermpc.reed_solomon import EncoderFactory, DecoderFactory
+from honeybadgermpc.reed_solomon import EncoderSelector, DecoderSelector
+from honeybadgermpc.ntl.helpers import AvailableNTLThreads
+from unittest.mock import patch
 
 
 @pytest.fixture
@@ -90,6 +94,24 @@ def test_fft_encode(fft_encoding_test_cases):
         assert actual == encoded
 
 
+def test_auto_encode_fft_disabled(encoding_test_cases):
+    # Just check if some encoder is being picked
+    for test_case in encoding_test_cases:
+        data, encoded, point = test_case
+        enc = EncoderFactory.get(point)
+        actual = enc.encode(data)
+        assert actual == encoded
+
+
+def test_auto_encode_fft_enabled(fft_encoding_test_cases):
+    # Just check if some encoder is being picked
+    for test_case in fft_encoding_test_cases:
+        data, encoded, point = test_case
+        enc = EncoderFactory.get(point)
+        actual = enc.encode(data)
+        assert actual == encoded
+
+
 def test_vandermonde_decode(decoding_test_cases):
     for test_case in decoding_test_cases:
         z, encoded, decoded, point = test_case
@@ -102,6 +124,22 @@ def test_fft_decode(fft_decoding_test_cases):
     for test_case in fft_decoding_test_cases:
         z, encoded, decoded, point = test_case
         dec = FFTDecoder(point)
+        actual = dec.decode(z, encoded)
+        assert actual == decoded
+
+
+def test_auto_decode_fft_disabled(decoding_test_cases):
+    for test_case in decoding_test_cases:
+        z, encoded, decoded, point = test_case
+        dec = DecoderFactory.get(point)
+        actual = dec.decode(z, encoded)
+        assert actual == decoded
+
+
+def test_auto_decode_fft_enabled(fft_decoding_test_cases):
+    for test_case in fft_decoding_test_cases:
+        z, encoded, decoded, point = test_case
+        dec = DecoderFactory.get(point)
         actual = dec.decode(z, encoded)
         assert actual == decoded
 
@@ -122,3 +160,95 @@ def test_wb_robust_decode(robust_decoding_test_cases):
         actual, actual_errors = dec.robust_decode(z, encoded)
         assert actual == decoded
         assert actual_errors == expected_errors
+
+
+def test_encoder_selection(galois_field):
+    # Very small n < 8. Vandermonde should always be picked
+    point = EvalPoint(galois_field, 4, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), VandermondeEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), VandermondeEncoder)
+
+    # Intermediate values of n (8 < n < 128
+    # Bad n (Nearest power of 2 is much higher) Vandermonde should
+    # always be picked
+    point = EvalPoint(galois_field, 65, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), VandermondeEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), VandermondeEncoder)
+
+    point = EvalPoint(galois_field, 40, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), VandermondeEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), VandermondeEncoder)
+
+    # Good n (Nearest power of 2 is close) FFT should be picked
+    point = EvalPoint(galois_field, 120, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), FFTEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), FFTEncoder)
+
+    point = EvalPoint(galois_field, 55, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), FFTEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), FFTEncoder)
+
+    # Large n. Always pick FFT
+    point = EvalPoint(galois_field, 255, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), FFTEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), FFTEncoder)
+
+    point = EvalPoint(galois_field, 257, use_fft=True)
+    assert isinstance(EncoderSelector.select(point, 1), FFTEncoder)
+    assert isinstance(EncoderSelector.select(point, 100000), FFTEncoder)
+
+
+@patch('psutil.cpu_count')
+def test_decoder_selection(mocked_cpu_count, galois_field):
+    # Very small n < 8. Vandermonde should always be picked
+    point = EvalPoint(galois_field, 4, use_fft=True)
+    for cpu_count in [1, 100]:
+        mocked_cpu_count.return_value = cpu_count
+        for batch_size in [1, 1000, 100000]:
+            DecoderSelector.set_optimal_thread_count(batch_size)
+            assert isinstance(DecoderSelector.select(point, batch_size),
+                              VandermondeDecoder)
+
+    # Small batches (~n). Reasonable number of threads. Pick FFT
+    point = EvalPoint(galois_field, 65, use_fft=True)
+    for cpu_count in [1, 2, 4, 8]:
+        mocked_cpu_count.return_value = cpu_count
+        for batch_size in [1, 16, 32]:
+            DecoderSelector.set_optimal_thread_count(batch_size)
+            assert isinstance(DecoderSelector.select(point, batch_size),
+                              FFTDecoder)
+
+    # Small n. Reasonable number of threads,
+    # Large batch sizes > ~ numthreads * n. Pick Vandermonde
+    point = EvalPoint(galois_field, 65, use_fft=True)
+    for cpu_count in [1, 2, 4, 8]:
+        mocked_cpu_count.return_value = cpu_count
+        for batch_size in [512, 1024, 2048, 4096]:
+            DecoderSelector.set_optimal_thread_count(batch_size)
+            assert isinstance(DecoderSelector.select(point, batch_size),
+                              VandermondeDecoder)
+
+    # Extremely large n. FFT should ideally be picked at reasonable batch sizes
+    point = EvalPoint(galois_field, 65536, use_fft=True)
+    for cpu_count in [1, 2, 4, 8]:
+        mocked_cpu_count.return_value = cpu_count
+        for batch_size in [512, 1024, 2048, 4096, 8192]:
+            DecoderSelector.set_optimal_thread_count(batch_size)
+            assert isinstance(DecoderSelector.select(point, batch_size),
+                              FFTDecoder)
+
+    # The scenarios above checked extreme cases. Below we check more rigorously based
+    # on the exact approximation formula. Ideally, the cases above should not change
+    # over time but the tests below will as the selection algorithm changes
+    for n in [32, 64, 128, 256]:
+        point = EvalPoint(galois_field, n, use_fft=True)
+        for cpu_count in [2 ** i for i in range(5)]:
+            mocked_cpu_count.return_value = cpu_count
+            for batch_size in [2 ** i for i in range(16)]:
+                DecoderSelector.set_optimal_thread_count(batch_size)
+                if batch_size > 0.5 * n * min(batch_size, AvailableNTLThreads()):
+                    assert isinstance(DecoderSelector.select(point, batch_size),
+                                      VandermondeDecoder)
+                else:
+                    assert isinstance(DecoderSelector.select(point, batch_size),
+                                      FFTDecoder)


### PR DESCRIPTION
Overview of commit

## Improved FFT
FFT has algorithmic improvements and improvements based on using NTL better. Here are some changes,
- Previously `_fft` was optimized to decrease the number of memory allocations. However, this led to a lot of ZZ_p objects being moved around which is fairly expensive. Instead, `_fft` makes more allocations now and moves around objects less often.
- Use procedural versions of NTL operations wherever possible. This also reduces the number of copies. For example, `A = B * C` -> `mul(A, B, C)`
- Some small optimisations are included to reduce computation based on how much of the FFT output we actually need. For example, reduce computation if we wanted only the first 5 values of the FFT output when using n=8.
- Moving towards a hybrid approach, FFT also uses Vandermonde matrices internally. The vandermonde matrices are precomputed when `fft` is called for the first time, and stored as a global variable. Access is protected with a mutex to enable multiple threads to use these precomputed values.

## Improved FNT Decode
- Q(.) in `fnt_decode_step2` is now only calculated upto `t+1` coefficients rather than up to `n` coefficients as suggested in the paper. This decreases the cost of the operation `P = Q * A` since Q is smaller.
- Use procedural versions of NTL operations wherever possible

## Better conversion between Python and NTL objects
Thanks to Chirantan's work on finding better techniques to convert between NTL objects and Python Integers, these operations have significantly improved.

## Parallelization!!
- `fft_batch_evaluate` and `fft_batch_interpolate` are parallelized using OpenMP. 
- Matrix multiplications used in `vandermonde_batch_evaluate` and `vandermonde_batch_interpolate` are parallelized by NTL automatically. This requires building NTL from source.
- `batch_fft_evaluate` introduced which also makes use of parallelization for FFT-based evaluation
- `SetNumThreads` introduces a common interface to set the number of threads for both OpenMP and NTL threads

## Building NTL from source
- NTL has significant improvements in mat_ZZ_p multiplications in recent versions which help improve vandermonde-based interpolation and evaluation
- This was also required for parallelization as noted above

## Automatic selection of encoder / decoder
Finally, this is what the main target of this PR was actually supposed to be. Based on experimental results, `OptimalEncoder` and `OptimalDecoder` set the number of threads and also automatically select if Vandermonde or FFT Encoder/Decoder should be used based on `n` and the batch size.

The number of threads is always selected to be `min(physical cores, batch_size)`. There are some odd cases where the optimal number of threads might be 1 more. However, this heuristic works for most cases.

### Decoder selection

Vandermonde-based interpolation was observed to always be better than FFT in the given range of `n` values {4, ..., 8196} at a large enough batch size. Therefore, for selecting Vandermonde, I only sought to find the exact batch size at which Vandermonde is better. The final selection was that if `batch_size > 0.5 * n * num_threads` then Vandermonde should be used, else FFT-based interpolation should be used. The `num_threads` parameter tries to fit observations for experiments which were run on both `t2.medium` and `c5.x4large` instances.

### Encoder selection

FFT-based evaluation is faster than evaluation using vandermonde matrices at almost all `n` where `n` is close to the nearest power of 2. Therefore, the selection just checks this condition by checking if `npow2 - self.n > npow2 // 4` where `npow2` is the nearest power of 2 greater than `n`.
