### PR TITLE
Implementation of batch_mimc

### DIFF
--- a/honeybadgermpc/progs/mimc.py
+++ b/honeybadgermpc/progs/mimc.py
@@ -6,10 +6,18 @@ from honeybadgermpc.mpc import PreProcessedElements, Subgroup
 ROUND = ceil(log(Subgroup.BLS12_381, 3))
 
 
+def mimc_plain(x, k):
+    inp = x
+    for ctr in range(ROUND):
+        inp = (inp + (k + ctr)) ** 3
+
+    return inp + k
+
+
 async def mimc_mpc(context, x, k):
     """
     MiMC block cipher encryption encrypts message x with secret key k,
-    where x and k are elements of F_p
+    where either x or k can be secret share, the other is an element of F_p
     See: https://eprint.iacr.org/2016/542.pdf
     """
     pp_elements = PreProcessedElements()
@@ -30,9 +38,36 @@ async def mimc_mpc(context, x, k):
     return inp + k
 
 
-def mimc_plain(x, k):
-    inp = x
-    for ctr in range(ROUND):
-        inp = (inp + (k + ctr)) ** 3
+async def mimc_mpc_batch(context, xs, k):
+    """
+    MiMC block cipher encryption encrypts blocks of message xs with secret key k,
+    where xs are a list of shared secrets, k is an element of F_p
+    """
+    pp_elements = PreProcessedElements()
 
-    return inp + k
+    # def cubing_share_array(): [x1,..., xK] -> [x1^3,..., xK^3]
+    async def cubing_share_array(xs):
+        rs, rs_sq, rs_cube = [], [], []
+        x3s = []
+
+        for x in xs:
+            r1, r2, r3 = pp_elements.get_cube(context)
+            y = await (x - r1).open()
+            rs.append(r1)
+            rs_sq.append(r2)
+            rs_cube.append(r3)
+
+        ys = await (context.ShareArray(xs) - context.ShareArray(rs)).open()
+        for i, y in enumerate(ys):
+            # [x^3] = 3y[r^2] + 3y^2[r] + y^3 + [r^3]
+            x3s.append(3*y*rs_sq[i] + 3*(y**2)*rs[i] + y**3 + rs_cube[i])
+
+        return x3s
+
+    # iterating the round function ROUND times
+    inp_array = xs
+    for ctr in range(ROUND):
+        inp_array = await cubing_share_array([(k + context.field(ctr)) + inp
+                                              for inp in inp_array])
+
+    return [inp + k for inp in inp_array]

--- a/tests/progs/test_mimc.py
+++ b/tests/progs/test_mimc.py
@@ -1,7 +1,8 @@
 from pytest import mark
+from random import randint
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
-from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
+from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain, mimc_mpc_batch
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 
 MIXINS = [BeaverMultiply()]
@@ -20,13 +21,35 @@ async def test_mimc(test_preprocessing, test_runner):
 
         # Compute F_MiMC_mpc
         mm = await mimc_mpc(context, x, key)
+        mm_open = await mm.open()
 
         # open x, then compute F_MiMC_plain
         x_open = await x.open()
         mp = mimc_plain(x_open, key)
 
         # Compare the MPC evaluation to the plain one
-        mm_ = await mm.open()
-        assert mm_ == mp
+        assert mm_open == mp
+
+    await test_runner(_prog, n, t, PREPROCESSING, k, MIXINS)
+
+
+@mark.asyncio
+async def test_mimc_mpc_batch(test_preprocessing, test_runner):
+    field = GF(Subgroup.BLS12_381)
+    key = field(randint(0, field.modulus))
+
+    async def _prog(context):
+        xs = [test_preprocessing.elements.get_rand(context) for _ in range(20)]
+
+        # Compute F_MiMC_mpc, mm - mimc_mpc
+        mm = await mimc_mpc_batch(context, xs, key)
+        mm_open = await context.ShareArray(mm).open()
+
+        # open x, then compute F_MiMC_plain, mp - mimc_plain
+        xs_open = await context.ShareArray(xs).open()
+        mp = [mimc_plain(x, key) for x in xs_open]
+
+        # Compare the MPC evaluation to the plain one
+        assert mm_open == mp
 
     await test_runner(_prog, n, t, PREPROCESSING, k, MIXINS)


### PR DESCRIPTION
The batch version of `mimc_mpc` takes a list of messages `xs = [m1, ..., mL]` and the secret key `k` as input and outputs the list `[F_MiMC(m1, k), ..., F_MiMC(mL, k)]`.