### PR TITLE
Noticeably log when decoding fails

### DIFF
--- a/honeybadgermpc/reed_solomon.py
+++ b/honeybadgermpc/reed_solomon.py
@@ -293,6 +293,7 @@ class IncrementalDecoder(object):
 
             if success is False:
                 # Guess was incorrect
+                logging.critical("Optimistic decoding failed")
                 self._guess_decoded = None
                 self._guess_encoded = None
                 self._optimistic = False


### PR DESCRIPTION
We should not raise an exception when decoding fails, because the code is written to tolerate Byzantine failures. However, it indicates either actual Byzantine behavior, or more likely, an error.