### PR TITLE
Optimize fnt_decode

### DIFF
--- a/honeybadgermpc/ntl/helpers.pyx
+++ b/honeybadgermpc/ntl/helpers.pyx
@@ -369,6 +369,7 @@ def fft_batch_interpolate(zs, ys_list, omega, modulus, int n):
         for i in prange(n_chunks):
             fnt_decode_step2_c(result_vec_list[i], A, Ad_evals_vec, z_vec, y_vec_list[i],
                                zz_omega, n)
+
     result = [[None] * k for _ in range(n_chunks)]
     for i in range(n_chunks):
         for j in range(k):

--- a/honeybadgermpc/ntl/rsdecode_impl.h
+++ b/honeybadgermpc/ntl/rsdecode_impl.h
@@ -218,7 +218,7 @@ void fnt_decode_step1(ZZ_pX &A, vec_ZZ_p &Ad_evals, vector<int>& zs,
 
     Ad_evals.SetLength(k);
     for (int i=0; i < k; i++) {
-        Ad_evals[i] = Ad_evals_all[zs[i]];
+        inv(Ad_evals[i], Ad_evals_all[zs[i]]);
     }
 }
 
@@ -230,7 +230,7 @@ void fnt_decode_step2(vec_ZZ_p &P_coeffs, ZZ_pX &A, vec_ZZ_p &Ad_evals,
     vec_ZZ_p nis;
     nis.SetLength(k);
     for (int i=0; i < k; i++) {
-        div(nis[i], ys[i], Ad_evals[i]);
+        mul(nis[i], ys[i], Ad_evals[i]);
     }
 
     // Build N
@@ -258,7 +258,7 @@ void fnt_decode_step2(vec_ZZ_p &P_coeffs, ZZ_pX &A, vec_ZZ_p &Ad_evals,
     }
 
     ZZ_pX P;
-    mul(P, Q, A);
+    MulTrunc(P, Q, A, k);
 
     VectorCopy(P_coeffs, P, k);
 }


### PR DESCRIPTION
Underestimated the cost of division. Significant speedup by changing a division to multiplication in `fnt_decode_step2`.