### PR TITLE
Refactor jubjub and shares (stability improvements)

### DIFF
--- a/honeybadgermpc/elliptic_curve.py
+++ b/honeybadgermpc/elliptic_curve.py
@@ -118,6 +118,8 @@ class Point(object):
     def __eq__(self, other: object) -> bool:
         if type(other) is Ideal:
             return False
+        elif self.curve != other.curve:
+            return False
 
         return (self.x, self.y) == (other.x, other.y)
 

--- a/honeybadgermpc/task_pool.py
+++ b/honeybadgermpc/task_pool.py
@@ -10,7 +10,7 @@ class TaskPool(object):
         self.tasks = Queue(loop=self.loop)
         self.workers = []
         for _ in range(num_workers):
-            worker = asyncio.ensure_future(self.worker(), loop=self.loop)
+            worker = asyncio.create_task(self.worker())
             self.workers.append(worker)
 
     async def worker(self):

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -1,5 +1,6 @@
 import asyncio
-from pytest import mark, raises
+from copy import copy
+from pytest import mark
 from honeybadgermpc.elliptic_curve import Ideal, Point, Jubjub
 from honeybadgermpc.progs.jubjub import SharedPoint, SharedIdeal, share_mul
 from honeybadgermpc.progs.mixins.share_arithmetic import (
@@ -43,18 +44,13 @@ async def run_test_program(prog, test_runner, n=n, t=t, k=10000,
     return await test_runner(prog, n, t, STANDARD_PREPROCESSING, k, mixins)
 
 
-async def shared_point_equals(a, b):
-    if a.curve != b.curve:
-        return False
-    elif type(a) != type(b):
-        return False
-    elif isinstance(a, (Ideal, SharedIdeal)):
-        return True
-
-    a_x, a_y, b_x, b_y = await asyncio.gather(
-        a.xs.open(), a.ys.open(), b.xs.open(), b.ys.open())
-
-    return (a_x, a_y) == (b_x, b_y)
+async def shared_point_equals(a_, b_):
+    """Test utility function-- opens the two shared points, and
+    then compares them that way. This should be faster than calling
+    the secret shared equality function
+    """
+    a, b = await asyncio.gather(a_.open(), b_.open())
+    return a == b
 
 
 def test_basic_point_functionality():
@@ -84,24 +80,20 @@ async def test_shared_point_equals(test_preprocessing, test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[0])
         p2 = SharedPoint.from_point(context, TEST_POINTS[1])
-        p3 = await SharedPoint.create(context, context.Share(
-            0), context.Share(1), Jubjub(Jubjub.Field(-2)))
 
-        assert await shared_point_equals(p1, p1)
-        assert not await shared_point_equals(p1, p2)
-        assert not await shared_point_equals(p1, p3)
+        # Different curve
+        t3 = copy(TEST_POINTS[0])
+        t3.curve = Jubjub(Jubjub.Field(-2))
+        p3 = SharedPoint.from_point(context, t3)
 
-    await run_test_program(_prog, test_runner)
+        p4 = SharedIdeal(TEST_CURVE)
 
+        eqs = await asyncio.gather(*[shared_point_equals(p1, p1),
+                                     shared_point_equals(p1, p2),
+                                     shared_point_equals(p1, p3),
+                                     shared_point_equals(p1, p4)])
 
-@mark.asyncio
-async def test_contains_shared_point(test_preprocessing, test_runner):
-    async def _prog(context):
-        # Will throw an exception if not on the curve
-        await SharedPoint.create(context, context.Share(0), context.Share(1))
-
-        with raises(ValueError):
-            await SharedPoint.create(context, context.Share(0), context.Share(2))
+        assert [True, False, False, False] == eqs
 
     await run_test_program(_prog, test_runner)
 
@@ -111,8 +103,7 @@ async def test_shared_point_creation_from_point(test_preprocessing, test_runner)
     async def _prog(context):
         p1 = Point(0, 1)
         p1s = SharedPoint.from_point(context, p1)
-        p2 = await SharedPoint.create(context, context.Share(0), context.Share(1))
-        assert await shared_point_equals(p1s, p2)
+        assert await p1s.open() == p1
 
     await run_test_program(_prog, test_runner)
 
@@ -124,7 +115,7 @@ async def test_shared_point_double(test_preprocessing, test_runner):
         actual_doubled = [SharedPoint.from_point(
             context, p.double()) for p in TEST_POINTS]
 
-        results = await asyncio.gather(*[p.double() for p in shared_points])
+        results = [p.double() for p in shared_points]
         assert all(await asyncio.gather(
             *[shared_point_equals(a, r) for a, r in zip(actual_doubled, results)]))
 
@@ -153,10 +144,7 @@ async def test_shared_point_add(test_preprocessing, test_runner):
         p1, p2, p3, p4 = [SharedPoint.from_point(
             context, point) for point in TEST_POINTS]
 
-        r1, r2, r3 = await asyncio.gather(
-            p2.add(ideal),
-            p1.add(p2),
-            p2.add(p3))
+        r1, r2, r3 = p2.add(ideal), p1.add(p2), p2.add(p3)
 
         assert all(await asyncio.gather(
             shared_point_equals(r1, p2),
@@ -174,10 +162,8 @@ async def test_shared_point_sub(test_preprocessing, test_runner):
         actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
 
         # We're going to be testing that given point p, p - p == p + (-p)
-        actual, result = await asyncio.gather(
-            asyncio.gather(*[p.sub(p) for p in shared_points]),
-            asyncio.gather(*[p1.add(p2)
-                           for p1, p2 in zip(shared_points, actual_negated)]))
+        actual = [p.sub(p) for p in shared_points]
+        result = [p1.add(p2) for p1, p2 in zip(shared_points, actual_negated)]
 
         assert all(await asyncio.gather(
             *[shared_point_equals(a, r) for a, r in zip(actual, result)]))
@@ -189,11 +175,11 @@ async def test_shared_point_sub(test_preprocessing, test_runner):
 async def test_shared_point_mul(test_preprocessing, test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[1])
-        p1_double = await p1.double()
-        p1_quad = await p1_double.double()
-        p4 = await p1.mul(4)
-        p5 = await p1.add(p4)
-        p1_quint = await p1_quad.add(p1)
+        p1_double = p1.double()
+        p1_quad = p1_double.double()
+        p4 = p1.mul(4)
+        p5 = p1.add(p4)
+        p1_quint = p1_quad.add(p1)
 
         assert await shared_point_equals(p1_quad, p4)
         assert await shared_point_equals(p1_quint, p5)
@@ -205,48 +191,46 @@ async def test_shared_point_mul(test_preprocessing, test_runner):
 async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[1])
-        p1_double = await p1.double()
-        p1_quad = await p1_double.double()
+        p1_double = p1.double()
+        p1_quad = p1_double.double()
 
         assert await shared_point_equals(
             p1_quad,
-            await p1.montgomery_mul(4))
+            p1.montgomery_mul(4))
 
         assert await shared_point_equals(
-            await p1_quad.add(p1),
-            await p1.montgomery_mul(5))
+            p1_quad.add(p1),
+            p1.montgomery_mul(5))
 
     await run_test_program(_prog, test_runner)
 
 
 @mark.asyncio
 async def test_share_mul(test_preprocessing, test_runner):
-    # bit_length = 255
     bit_length = 80  # Short key for testing
-    test_preprocessing.generate('bits', n, t, k=2000)
 
     async def _prog(context):
         p = TEST_POINTS[1]
-        multiplier_ = [test_preprocessing.elements.get_bit(context)
-                       for i in range(bit_length)]
-        multiplier = Jubjub.Field(0)
-        for i in range(bit_length):
-            multiplier += (2**i) * multiplier_[i]
-        multiplier = await multiplier.open()
-        p_mul = int(multiplier) * p
+
+        multiplier_ = Jubjub.Field(0)
+        m_bits = [test_preprocessing.elements.get_bit(context)
+                  for i in range(bit_length)]
+
+        for idx, m in enumerate(m_bits):
+            multiplier_ += (2**idx) * m
 
         # Compute share_mul
-        p1_ = await share_mul(context, multiplier_, p)
-        px, py = await asyncio.gather(p1_.xs.open(), p1_.ys.open())
+        p1_ = await share_mul(context, m_bits, p)
+        result = await p1_.open()
 
         # Assertation
+        multiplier = await multiplier_.open()
         if multiplier == Jubjub.Field(0):
-            assert (px, py) == (Jubjub.Field(0), Jubjub.Field(1))
+            assert result == p
         else:
-            assert px == p_mul.x
-            assert py == p_mul.y
+            assert result == int(multiplier) * p
 
-        q1_ = await share_mul(context, multiplier_, Ideal(TEST_CURVE))
+        q1_ = await share_mul(context, m_bits, Ideal(TEST_CURVE))
         q2_ = SharedIdeal(TEST_CURVE)
         assert await shared_point_equals(q1_, q2_)
 

--- a/tests/progs/test_mimc_jubjub_pkc.py
+++ b/tests/progs/test_mimc_jubjub_pkc.py
@@ -1,5 +1,6 @@
 from pytest import mark
 from random import randint
+import asyncio
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
 from honeybadgermpc.progs.mixins.share_arithmetic import (
@@ -37,7 +38,8 @@ async def test_mimc_jubjub_pkc(test_preprocessing, test_runner):
         # Encryption & Decryption
         cipher = mimc_encrypt(pub_key, plaintext, seed)
         decrypted_value = await mimc_decrypt(context, priv_key, cipher)
+        decrypted = await asyncio.gather(*[d.open() for d in decrypted_value])
 
-        assert (await context.ShareArray(decrypted_value).open()) == plaintext
+        assert decrypted == plaintext
 
     await test_runner(_prog, n, t, PREPROCESSING, k, STANDARD_ARITHMETIC_MIXINS)


### PR DESCRIPTION
This refactors jubjub to explicitly use `ShareFuture`s, which helps clean up its interface and usage greatly. This accomplishes this my making its methods no longer async, but adding in `open` and `equals`, which are async and provide boilerplate code that was otherwise needed. This also updates how we assign ids to incoming shares (there were some issues with it).

Finally, this updates the existing code to use `create_task` instead of `ensure_future`, and updates existing jubjub code (mimc, etc.)