### PR TITLE
Removed docs from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     - env: BUILD=tests
     - env: BUILD=flake8
-    - env: BUILD=docs
+    # - env: BUILD=docs
 
 install:  .ci/travis-install.sh
 


### PR DESCRIPTION
Currently, travis builds are failing. While investigation / improvements of docker/travis occur, this is a stopgap so that our builds will pass. This is part of the effort to address #288 