### PR TITLE
Refactoring travis and docker

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM dsluiuc/honeybadgermpc-docker-base AS travis-image
+
+WORKDIR /usr/src/HoneyBadgerMPC
+COPY . /usr/src/HoneyBadgerMPC
+
+RUN pip install -e .["tests,docs"]
+RUN make -C apps/shuffle/cpp -j
+

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -6,9 +6,9 @@ pip install --upgrade pip
 
 if [ "${BUILD}" == "tests" ]; then
     pip install --upgrade codecov
-    docker-compose -f .travis.compose.yml build --no-cache test-hbmpc
+    docker-compose -f .travis.compose.yml build test-hbmpc
 elif [ "${BUILD}" == "flake8" ]; then
     pip install --upgrade flake8 pep8-naming
 elif [ "${BUILD}" == "docs" ]; then
-    docker-compose -f .travis.compose.yml build --no-cache test-hbmpc
+    docker-compose -f .travis.compose.yml build test-hbmpc
 fi

--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,0 +1,8 @@
+FROM dsluiuc/honeybadgermpc-docker-base
+
+WORKDIR /usr/src/HoneyBadgerMPC
+
+COPY . /usr/src/HoneyBadgerMPC
+
+RUN pip install -e .
+RUN make -C apps/shuffle/cpp -j

--- a/.travis.compose.yml
+++ b/.travis.compose.yml
@@ -1,12 +1,11 @@
-version: '3'
+version: '3.4'
 
 services:
   test-hbmpc:
     build:
       context: .
-      dockerfile: Dockerfile
-      args:
-        - BUILD
+      dockerfile: .ci/Dockerfile
+      target: travis-image
     volumes:
       - ./aws:/usr/src/HoneyBadgerMPC/aws
       - ./conf:/usr/src/HoneyBadgerMPC/conf
@@ -20,9 +19,4 @@ services:
       - ./Makefile:/usr/src/HoneyBadgerMPC/Makefile
       - ./pytest.ini:/usr/src/HoneyBadgerMPC/pytest.ini
       - ./setup.py:/usr/src/HoneyBadgerMPC/setup.py
-      - ./pairing/pypairing/__init__.py:/usr/src/HoneyBadgerMPC/pairing/pypairing/__init__.py
-      - ./pairing/src:/usr/src/HoneyBadgerMPC/pairing/src
-      - ./pairing/benches:/usr/src/HoneyBadgerMPC/pairing/benches
-      - ./pairing/Cargo.toml:/usr/src/HoneyBadgerMPC/pairing/Cargo.toml
-      - ./pairing/setup.py:/usr/src/HoneyBadgerMPC/pairing/setup.py
       - /usr/src/HoneyBadgerMPC/honeybadgermpc/ntl  # Directory _not_ mounted from host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,11 @@
-version: '3'
+version: '3.4'
 
 services:
   honeybadgermpc:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        BUILD: dev,aws
+      target: dev-release
     volumes:
       - ./apps:/usr/src/HoneyBadgerMPC/apps
       - ./progs:/usr/src/HoneyBadgerMPC/progs

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import io
 import os
 
 from setuptools import setup, find_packages
@@ -65,17 +64,19 @@ EXTRAS = {
 here = os.path.abspath(os.path.dirname(__file__))
 
 try:
-    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-        long_description = '\n' + f.read()
+    with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+        long_description = f"\n{f.read()}"
 except FileNotFoundError:
     long_description = DESCRIPTION
 
-about = {}
 if not VERSION:
+    g = {}
+
+    # TODO: consolidate how we do this
     with open(os.path.join(here, NAME, '__version__.py')) as f:
-        exec(f.read(), about)
-else:
-    about['__version__'] = VERSION
+        exec(f.read(), g)
+        VERSION = g['__version__']
+
 
 extra_compile_args = ['-std=c++11', '-O3', '-pthread', '-fopenmp', '-march=native']
 extra_link_args = ['-std=c++11', '-O3', '-pthread', '-fopenmp', '-lntl', '-lgmp', '-lm',
@@ -93,7 +94,7 @@ extensions = [
 
 setup(
     name=NAME,
-    version=about['__version__'],
+    version=VERSION,
     description=DESCRIPTION,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR does 2 things at once-- it fixes the current issue where Travis builds break, and also cuts the build times down to 1-2 min for docs and 8-9 min for tests.

We achieve this by leveraging multi-stage docker builds such that we can create an image with all of our dependencies installed, and use it in later stages to build on top of it. Thus, much of the work of the final stage of building the docker image is just downloading the image. 

However, now we have an added task-- when we install new dependencies, we need to push to dockerhub, which requires someone to build the image locally. If I find anything quick that can avoid that I'll add it in.

This tackles https://github.com/initc3/HoneyBadgerMPC/issues/288, as well as https://github.com/initc3/HoneyBadgerMPC/issues/239