### PR TITLE
More batching and other changes

### DIFF
--- a/honeybadgermpc/hbavss.py
+++ b/honeybadgermpc/hbavss.py
@@ -103,9 +103,11 @@ class HbAvssLight():
         # RECEIVE LOOP
         ok_set = set()
         recovery_set = set()
+        implicate_set = set()
         recovery_shares = [[] for _ in range(len(commitments))]
         sent_recovery = False
         output = False
+        recovered = False
         while True:
             if len(ok_set) == 2 * self.t + 1 and share_valid and not output:
                 if len(commitments) == 1:
@@ -128,14 +130,20 @@ class HbAvssLight():
                     self.output_queue.put_nowait((dealer_id, avss_id, share_ints))
                 output = True
                 share_valid = True
+                recovered = True
                 multicast((HbAVSSMessageType.OK, ""))
-            # We can safely stop running at this point
-            if len(ok_set) == self.n:
+
+            # Conditions where we can terminate
+            if len(ok_set) == self.n or len(implicate_set) >= self.t + 1 \
+                    or len(ok_set) >= 2*self.t + 1 and (sent_recovery or recovered):
                 break
 
             sender, avss_msg = await recv()  # First value is `sid` (not true anymore?)
             if avss_msg[0] == HbAVSSMessageType.OK and sender not in ok_set:
                 ok_set.add(sender)
+            if avss_msg[0] == HbAVSSMessageType.IMPLICATE \
+                    and sender not in implicate_set:
+                implicate_set.add(sender)
             if avss_msg[0] == HbAVSSMessageType.IMPLICATE \
                     and not sent_recovery and share_valid:
                 j_sk = avss_msg[1]
@@ -296,10 +304,13 @@ class HbAvssBatch():
         self.field = ZR
         self.poly = polynomials_over(self.field)
         self.poly_commit = PolyCommitConst(crs)
+        self.poly_commit.preprocess_prover()
+        self.poly_commit.preprocess_verifier()
 
         self.avid_msg_queue = asyncio.Queue()
         self.tasks = []
         self.shares_future = asyncio.Future()
+        self.output_queue = asyncio.Queue()
 
     async def _recv_loop(self, q):
         while True:
@@ -352,17 +363,17 @@ class HbAvssBatch():
         dispersal_msg = await avid.retrieve(tag, self.my_id)
         encrypted_witnesses = loads(dispersal_msg)
 
-        secret_size = len(commitments)
+        secret_count = len(commitments)
 
         # all_encrypted_witnesses: n
         shared_key = pow(ephemeral_public_key, self.private_key)
 
-        shares = [None] * secret_size
-        auxes = [None] * secret_size
-        witnesses = [None] * secret_size
+        shares = [None] * secret_count
+        auxes = [None] * secret_count
+        witnesses = [None] * secret_count
         # Decrypt
         all_shares_valid = True
-        for k in range(secret_size):
+        for k in range(secret_count):
             try:
                 shares[k], auxes[k], witnesses[k] = SymmetricCrypto.decrypt(
                     str(shared_key).encode(), encrypted_witnesses[k])
@@ -370,23 +381,28 @@ class HbAvssBatch():
                 all_shares_valid = False
                 multicast((HbAVSSMessageType.IMPLICATE, self.private_key, k))
                 break
-            if not self.poly_commit.verify_eval(
-                    commitments[k], self.my_id+1, shares[k], auxes[k], witnesses[k]):
-                # invalid share found and send all implicate msg
+        # call if decryption was successful
+        if all_shares_valid:
+            if not self.poly_commit.batch_verify_eval(
+                    commitments, self.my_id+1, shares, auxes, witnesses):
                 all_shares_valid = False
-                multicast((HbAVSSMessageType.IMPLICATE, self.private_key, k))
-                break
-
+                # Find which share was invalid and implicate
+                for k in range(secret_count):
+                    if not self.poly_commit.verify_eval(
+                            commitments[k], self.my_id+1, shares[k], auxes[k], witnesses[k]):  # (# noqa: E501)
+                        multicast((HbAVSSMessageType.IMPLICATE, self.private_key, k))
+                        break
         if all_shares_valid:
             multicast((HbAVSSMessageType.OK, ""))
 
         ok_set = set()
-        ready_set = set()
+        implicate_set = set()
         r1_set = set()
         r2_set = set()
-        ready_sent = r1_sent = r2_sent = False
+        r1_sent = r2_sent = False
         r1_phi = [None] * self.n
         r2_phi = [None] * self.n
+        output = False
 
         while True:
             # main recv loop for Bracha-style agreement and implicate handling
@@ -394,11 +410,11 @@ class HbAvssBatch():
             # OK
             if avss_msg[0] == HbAVSSMessageType.OK and sender not in ok_set:
                 ok_set.add(sender)
-            # READY
-            if avss_msg[0] == HbAVSSMessageType.READY and sender not in ready_set:
-                ready_set.add(sender)
             # IMPLICATE
-            if avss_msg[0] == HbAVSSMessageType.IMPLICATE:
+            if avss_msg[0] == HbAVSSMessageType.IMPLICATE \
+                    and sender not in implicate_set:
+                implicate_set.add(sender)
+            if avss_msg[0] == HbAVSSMessageType.IMPLICATE and not r1_sent:
                 # validate the implicate
                 if not await self._handle_implication(
                         avid, tag, ephemeral_public_key, commitments,
@@ -407,11 +423,11 @@ class HbAvssBatch():
                 # proceed to share recovery
                 logger.debug("[%d] Share recovery activated by %d", self.my_id, sender)
                 # setup the coordinates for interpolation
-                c_coords = [None] * secret_size
-                phi_coords = [None] * secret_size
-                aux_coords = [None] * secret_size
-                w_coords = [None] * secret_size
-                for i in range(secret_size):
+                c_coords = [None] * secret_count
+                phi_coords = [None] * secret_count
+                aux_coords = [None] * secret_count
+                w_coords = [None] * secret_count
+                for i in range(secret_count):
                     c_coords[i] = (i, commitments[i])
                     phi_coords[i] = (i, shares[i])
                     aux_coords[i] = (i, auxes[i])
@@ -453,39 +469,44 @@ class HbAvssBatch():
                     send(j, (HbAVSSMessageType.RECOVERY2, phi_j_i))
 
             # enough R2 received -> output result
-            # Does this actually do robust interpolation?
-            if len(r2_set) >= 2 * self.t + 1:
-                recovered_result = [None] * secret_size
+            if len(r2_set) >= 2 * self.t + 1 and not all_shares_valid:
                 r2_phi_coords = [(i, r2_phi[i])
                                  for i in range(self.n) if r2_phi[i] is not None]
                 r2_phi_poly = self.poly.interpolate(r2_phi_coords)
-                for k in range(secret_size):
-                    recovered_result[k] = r2_phi_poly(k)
-                if not self.shares_future.done():
-                    self.shares_future.set_result(recovered_result)
+                for k in range(secret_count):
+                    shares[k] = r2_phi_poly(k)
+                int_shares = [int(share) for share in shares]
+                self.output_queue.put_nowait((dealer_id, avss_id, int_shares))
+                output = True
+                all_shares_valid = True
+                multicast((HbAVSSMessageType.OK, ""))
 
-            # if 2t+1 OK or t+1 READY -> send all ready
-            if not ready_sent and \
-                    (len(ok_set) >= 2 * self.t + 1 or len(ready_set) >= self.t + 1):
-                ready_sent = True
-                multicast((HbAVSSMessageType.READY, ""))
-
-            # if 2t+1 ready -> output shares
-            if len(ready_set) >= 2 * self.t + 1:
+            # if 2t+1 okay -> output shares
+            if len(ok_set) >= 2 * self.t + 1:
                 # output result by setting the future value
-                if all_shares_valid and not self.shares_future.done():
-                    self.shares_future.set_result(shares)
+                if all_shares_valid and not output:
+                    int_shares = [int(shares[i]) for i in range(len(shares))]
+                    self.output_queue.put_nowait((dealer_id, avss_id, int_shares))
+                    output = True
+
+            # Conditions where we can terminate
+            if len(ok_set) == self.n or len(implicate_set) >= 2*self.t \
+                    or (len(ok_set) >= 2*self.t + 1 and r2_sent and output):
+                break
 
     def _get_dealer_msg(self, values, n):
         # Sample a random degree-(t,t) bivariate polynomial φ(·,·)
         # such that each φ(0,k) = sk and φ(i,k) is Pi’s share of sk
-        secret_size = len(values)
-        phi = [None] * secret_size
-        commitments = [None] * secret_size
-        aux_poly = [None] * secret_size
+        while len(values) % (self.t + 1) != 0:
+            values.append(0)
+        secret_count = len(values)
+        # batch_count = secret_count/(self.t + 1)
+        phi = [None] * secret_count
+        commitments = [None] * secret_count
+        aux_poly = [None] * secret_count
         # for k ∈ [t+1]
         #   Ck, auxk <- PolyCommit(SP,φ(·,k))
-        for k in range(secret_size):
+        for k in range(secret_count):
             phi[k] = self.poly.random(self.t, values[k])
             commitments[k], aux_poly[k] = self.poly_commit.commit(phi[k])
 
@@ -497,8 +518,8 @@ class HbAvssBatch():
         dispersal_msg_list = [None] * n
         for i in range(n):
             shared_key = pow(self.public_keys[i], ephemeral_secret_key)
-            z = [None] * secret_size
-            for k in range(secret_size):
+            z = [None] * secret_count
+            for k in range(secret_count):
                 witness = self.poly_commit.create_witness(phi[k], aux_poly[k], i+1)
                 z[k] = SymmetricCrypto.encrypt(str(shared_key).encode(),
                                                (phi[k](i+1), aux_poly[k](i+1), witness))

--- a/honeybadgermpc/poly_commit_const.py
+++ b/honeybadgermpc/poly_commit_const.py
@@ -1,4 +1,4 @@
-from honeybadgermpc.betterpairing import ZR, G1, G2
+from honeybadgermpc.betterpairing import ZR, G1, G2, pair
 from honeybadgermpc.polynomial import polynomials_over
 
 
@@ -47,6 +47,23 @@ class PolyCommitConst:
         lhs = c.pair_with(self.ghats[0])
         rhs = witness.pair_with(self.ghats[1] / (self.ghats[0] ** i)) \
             * self.gg**phi_at_i * self.gh**phi_hat_at_i
+        return lhs == rhs
+
+    def batch_verify_eval(self, commits, i, shares, auxes, witnesses):
+        assert len(commits) == len(shares) and len(commits) == len(witnesses) \
+            and len(commits) == len(auxes)
+        commitprod = G1.one()
+        witnessprod = G1.one()
+        sharesum = ZR(0)
+        auxsum = ZR(0)
+        for j in range(len(commits)):
+            commitprod *= commits[j]
+            witnessprod *= witnesses[j]
+            sharesum += shares[j]
+            auxsum += auxes[j]
+        lhs = pair(commitprod, self.ghats[0])
+        rhs = pair(witnessprod, self.ghats[1] * self.ghats[0]**(-i)) \
+            * (self.gg ** sharesum) * (self.gh ** auxsum)
         return lhs == rhs
 
     def preprocess_verifier(self, level=4):


### PR DESCRIPTION
Changelog:
Added more termination conditions to hbavss lite and batch
Removed ready messages from hbavss batch (protocol update to follow)
Switched batch avss (and appropriate test cases) to use output queues instead of futures
Batch avss can accept an arbitrarily large batch
PolycommitConst now has a batch verifyeval option which saves computational costs
Batch avss optimistically uses this batch verifyeval and checks piecewise upon detecting a fault
Batch avss objects now start with some light precomputation in init. Make sure to start benchmarks after this happens (and feel free to adjust the precomputation level).

Todo:
batch hbavss does not handle faults when the batch is larger than t+1. This can be added of course, I'm just not sure if it's the highest priority at the moment


