### PR TITLE
Make shuffle so that tests pass on local docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN pip install Cython
 RUN pip install -e .
 RUN pip install pairing/
 
-
+RUN make -C apps/shuffle/cpp
 
 # Installs test dependencies
 # For now, upload this to docker-hub


### PR DESCRIPTION
Overlooked this in the rush to get travis working, this will make it so that you can run `docker-compose build && docker-compose up` and have all the tests pass locally.