### PR TITLE
Batch implementation of RanDouSha

### DIFF
--- a/tests/test_hyper_invertible.py
+++ b/tests/test_hyper_invertible.py
@@ -7,14 +7,15 @@ from honeybadgermpc.reed_solomon import Algorithm, DecoderFactory
 
 @mark.asyncio
 @mark.parametrize("n", [4, 7])
-async def test_generate_double_shares(test_router, polynomial, galois_field, n):
+@mark.parametrize("k", [1, 10])
+async def test_generate_double_shares(test_router, polynomial, galois_field, n, k):
     t = (n-1)//3
     sends, receives, _ = test_router(n)
     shares_per_party = await asyncio.gather(*[generate_double_shares(
-        n, t, i, sends[i], receives[i], galois_field) for i in range(n)])
+        n, t, i, sends[i], receives[i], galois_field, k) for i in range(n)])
     assert len(shares_per_party) == n
-    assert all(len(random_shares) == n-2*t for random_shares in shares_per_party)
-    random_values = [None]*(n-2*t)
+    assert all(len(random_shares) == (n-2*t)*k for random_shares in shares_per_party)
+    random_values = []
     eval_point = EvalPoint(galois_field, n, use_fft=True)
     decoder = DecoderFactory.get(eval_point, Algorithm.FFT)
     for i, shares in enumerate(zip(*shares_per_party)):
@@ -22,5 +23,5 @@ async def test_generate_double_shares(test_router, polynomial, galois_field, n):
         r_t = polynomial(decoder.decode(list(range(n)), shares_t))(0)
         r_2t = polynomial(decoder.decode(list(range(n)), shares_2t))(0)
         assert r_t == r_2t
-        random_values[i] = r_t
-    assert len(set(random_values)) == n-2*t
+        random_values.append(r_t)
+    assert len(set(random_values)) == (n-2*t) * k


### PR DESCRIPTION
This is a batched version of RanDouSha (hyper-invertible.py). It now takes an additional parameter `k`, and outputs `(n-2t)k` random double sharings. By using the batch version of `decode`/`encode` and sending only one message for the batch it can avoid the startup cost of the inverse vandermonde matrix, etc., reduce the number of messages sent, python function calls, etc.