### PR TITLE
Decrease docker image size and speedups for travis

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,3 @@
-FROM dsluiuc/honeybadgermpc-docker-base AS travis-image
+FROM dsluiuc/honeybadgermpc-test-image
 
-WORKDIR /usr/src/HoneyBadgerMPC
 COPY . /usr/src/HoneyBadgerMPC
-
-RUN pip install -e .["tests,docs"]
-RUN make -C apps/shuffle/cpp -j
-

--- a/.travis.Dockerfile
+++ b/.travis.Dockerfile
@@ -1,8 +1,0 @@
-FROM dsluiuc/honeybadgermpc-docker-base
-
-WORKDIR /usr/src/HoneyBadgerMPC
-
-COPY . /usr/src/HoneyBadgerMPC
-
-RUN pip install -e .
-RUN make -C apps/shuffle/cpp -j

--- a/.travis.compose.yml
+++ b/.travis.compose.yml
@@ -1,11 +1,10 @@
-version: '3.4'
+version: '3'
 
 services:
   test-hbmpc:
     build:
       context: .
       dockerfile: .ci/Dockerfile
-      target: travis-image
     volumes:
       - ./aws:/usr/src/HoneyBadgerMPC/aws
       - ./conf:/usr/src/HoneyBadgerMPC/conf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing to HoneyBadgerMPC
+
 See [Getting Started](docs/development/getting-started.rst) to get setup for
 developing HoneyBadgerMPC.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
-# Dockerfile contains multiple levels of images--
-# First, a base image containing dependencies shared by all other images:
-#   - apt dependencies
-#   - rust
-#   - ntl
-#   - pbc
-#   - charm
-#   - base pip dependencies (cython & setup.py)
-# 
-# Thereafter, it adds ever increasing levels of dependencies-- 
-#   - Test requirements (including doc requirements)
-#   - Dev requirements (including aws)
+# This base image contains the bare minimum dependencies / environment details
+# to create the subsequent images-- this is where to put dependencies that are
+# absolutely required to run our code in travis, build dev dependencies, and 
+# eventually create our dev image. This is to be as small as possible to keep 
+# travis times down.
 #
 # In order to build and push this to dockerhub, run:
 # docker build . --target test-image --tag dsluiuc/honeybadgermpc-docker-base
@@ -18,7 +11,7 @@ FROM python:3.7.3-slim AS base-image
 
 # Allows for log messages to be immediately dumped to the 
 # stream instead of being buffered.
-ENV PYTHONUNBUFFERED    1 
+ENV PYTHONUNBUFFERED 1
 
 # Path variables needed for Charm
 ENV LIBRARY_PATH        /usr/local/lib
@@ -29,24 +22,23 @@ ENV LD_LIBRARY_PATH     /usr/local/lib
 # which relies on certain code that doesn't work in container's default shell.
 RUN ln -sf bash /bin/sh
 
-# Install apt dependencies
+RUN pip install --upgrade pip virtualenv
+
+# Derived from https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m virtualenv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+RUN echo "alias cls=\"clear && printf '\e[3J'\"" >> ~/.bashrc
+
+# Packages absolutely required to run our tests
+# Installing gcc because we need libgomp.so.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bison \
-    curl \
-    flex \
-    g++ \
-    git \
-    iproute2 \
+    gcc \ 
     libflint-dev \
     libgmp-dev \
     libmpc-dev \
-    libmpfr-dev \
-    libssl-dev \
-    make \
-    openssl \
-    tmux \
-    wget \
-    vim 
+    libmpfr-dev 
 
 # This is needed otherwise the build for the power sum solver will fail.
 # This is a known issue in the version of libflint-dev in apt.
@@ -54,67 +46,94 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # This has been fixed if we pull the latest code from the repo. However, we want
 # to avoid compiling the lib from the source since it adds 20 minutes to the build.
 RUN sed -i '30c #include "flint/flint.h"' /usr/include/flint/flintxx/flint_classes.h
-RUN echo "alias cls=\"clear && printf '\e[3J'\"" >> ~/.bashrc
 
-# RUN python -m venv /opt/venv
-# ENV PATH "/opt/venv/bin:${PATH}"
 
-# Downloads rust and sets it up
+# This image will contain all of the apt packages required to build dependencies.
+# It will also download dependencies, build them from source, and install pip dependencies 
+# using pipenv. 
+FROM base-image AS build-image
+
+# Install apt dependencies required to build dependencies, or are otherwise
+# not required for testing (see: vim, tmux)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bison \
+    curl \
+    flex \
+    g++ \
+    git \
+    iproute2 \
+    libssl-dev \
+    make \
+    openssl \
+    tmux \
+    wget \
+    vim 
+
+# Downloads rust/cargo and sets it up
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-10-24
 ENV PATH "/root/.cargo/bin:${PATH}"
 
 # Download and build NTL from source
 # Shoup recommends not using O3
+WORKDIR /
 RUN curl -so - https://www.shoup.net/ntl/ntl-11.3.2.tar.gz | tar xzvf -
 WORKDIR /ntl-11.3.2/src  
 RUN ./configure CXXFLAGS="-g -O2 -fPIC -march=native -pthread -std=c++11" 
-RUN make -j 
-RUN make install -j
-WORKDIR /
-
+RUN make 
+RUN make install
 
 # Install betterpairing
+WORKDIR /
 RUN curl -so - https://crypto.stanford.edu/pbc/files/pbc-0.5.14.tar.gz | tar xzvf - 
 WORKDIR /pbc-0.5.14/
 RUN ./configure
-RUN make -j
-RUN make install -j
-WORKDIR /
+RUN make
+RUN make install
 
-
-# Downloads and installs charm
+# Install charm
+WORKDIR /usr/src/HoneyBadgerMPC
 RUN git clone https://github.com/JHUISI/charm.git 
-WORKDIR /charm/
+WORKDIR /usr/src/HoneyBadgerMPC/charm
 RUN git reset --hard be9587ccdd4d61c591fb50728ebf2a4690a2064f
 RUN ./configure.sh
-RUN make install -j
-WORKDIR /
+RUN make
 
-
-# Below derived from https://pythonspeed.com/articles/multi-stage-docker-python/
 WORKDIR /usr/src/HoneyBadgerMPC
 COPY . /usr/src/HoneyBadgerMPC
 
-RUN pip install --upgrade pip
-RUN pip install Cython
-RUN pip install -e .
-RUN pip install pairing/
-
+# Build compute-power-sums
 RUN make -C apps/shuffle/cpp
 
-# Installs test dependencies
-# For now, upload this to docker-hub
-#
-# TODO: see if we can shrink this image size more.
-# I was able to do it by copying over from LIBRARY_PATH, /opt/venv/ 
-# and compiled outputs from apps and ntl, but I couldn't manage to get
-# lib_solver to import correctly.
+# Install all pip dependencies
+# One caveat about our pipfile-- we cannot specify cython to install
+# before honeybadgermpc in the pipfile, so we install it first
+WORKDIR /usr/src/HoneyBadgerMPC/
+RUN pip install charm/ pairing/
+RUN pip install -e .[tests,docs]
+
+# This is the image used locally through docker-compose for development.
+# This will contain all of the sources used to build dependencies, as 
+# well as all dependencies specified in Pipfile.
+FROM build-image AS dev-image
+RUN pip install -e .[dev]
+
+
+# Minimal image to run tests on. This pulls in the compiled dependencies from 
+# build-image, which keeps the image size down. This should be pushed up to dockerhub.
 FROM base-image AS test-image
-RUN pip install -e .["tests,docs"]
+WORKDIR /usr/src/HoneyBadgerMPC/
 
-# Actual image to use for dev work
-FROM test-image as dev-release
-# -e so that it installs locally
-# RUN pip install --user -e .["dev,aws"]
-RUN pip install -e .["dev,aws"]
+# Copies over dependencies built from source
+COPY --from=build-image /usr/local/lib/ /usr/local/lib/
 
+# Copies over compute_power_sums binary
+COPY --from=build-image /usr/local/bin/compute-power-sums /usr/local/bin/compute-power-sums
+
+# Copies over installed pip dependencies
+COPY --from=build-image $VIRTUAL_ENV $VIRTUAL_ENV
+
+# Copies over built ntl code
+COPY --from=build-image /usr/src/HoneyBadgerMPC/honeybadgermpc/ntl/ honeybadgermpc/ntl/
+
+# Copies lib_solver
+COPY --from=build-image /usr/src/HoneyBadgerMPC/*.so .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include pyproject.toml

--- a/README.md
+++ b/README.md
@@ -17,16 +17,21 @@ properties:
 * Prevents data breaches even if some nodes are compromised.
 
 ## [HoneyBadgerMPC Subprotocols](docs/subprotocols.rst)
+
 See [docs/subprotocols.rst](docs/subprotocols.rst).
 
 ## [Contributing to HoneyBadgerMPC](CONTRIBUTING.md)
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) to get started!
 
 ## [Roadmap](ROADMAP.md)
+
 See [ROADMAP.md](ROADMAP.md).
 
 ## [Documentation](/docs)
+
 The HoneyBadgerMPC documentation is under the [docs/](docs/) directory.
 
 ## [Changelog](CHANGELOG.md)
+
 See [CHANGELOG.md](CHANGELOG.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,7 @@
 *draft*
 
 ## Benchmarking
+
 * Measure the number of Beaver triples that can be generated per seconds.
 * Become aware of where the bottlenecks are, for each subprotocol.
 * One performance goal is to be able to have similar performance metrics as viff
@@ -12,8 +13,8 @@
 * Identify which parts of the implementation need performance optimizations, and
   write C or Rust extensions for these parts.
 
-
 ## Project structure
+
 * Refine the project structure over time to reflect the modularity and composability
   of the protocol.
 * Possibly, eventually package and distribute the key sub-protocols as standalone,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: dev-release
+      target: dev-image
     cap_add:
       - NET_ADMIN
     volumes:

--- a/docs/ci.rst
+++ b/docs/ci.rst
@@ -92,14 +92,16 @@ For the ``docs`` and ``tests`` build jobs (i.e.: ``BUILD=docs`` and
 ``BUILD=tests`` matrix rows), `docker-compose is used
 <using docker in builds>`_. The ``Dockerfile`` used is located under the
 ``.ci/`` directory whereas the ``docker-compose`` file is under the root of
-the project and is named ``.travis.compose.yml``. Both files are similar to
-the ones used for development. One key difference is that only the docs or
-tests requirements are installed, depending on the value of the ``BUILD``
-environment variable.
+the project and is named ``.travis.compose.yml``. This Dockerfile simply pulls
+the last-pushed version of our testing docker-image from Dockerhub, copies over
+cloned code, and then runs the tests. This prevents having to install
+dependencies in travis, which vastly cuts down our CI time.
 
-.. note:: Some work could perhaps be done to limit the duplication accross the
-    two Dockerfiles, by using a base Dockerfile for instance, but this may
-    also complicate things so for now some duplication is tolerated.
+.. note:: In order to achieve this, we utilize dockerhub's `automated builds`_.
+    Whenever we push to the ``dev`` branch, dockerhub will build a new docker image,
+    which then gets pulled down in future travis runs. If you need to rebuild
+    the image used by travis for some reason (say, adding a dependency), use the
+    ``build_dockerhub_image.sh`` script in ``scripts/``
 
 
 Code coverage
@@ -175,3 +177,4 @@ Recommended readings
 .. _coverage configuration: https://docs.codecov.io/docs/coverage-configuration
 .. _Codecov Outside Docker: https://docs.codecov.io/docs/testing-with-docker#section-codecov-outside-docker
 .. _team bot: https://docs.codecov.io/docs/team-bot
+.. _automated builds: https://docs.docker.com/docker-hub/builds/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython", "setuptools", "wheel"]

--- a/scripts/build_dockerhub_image.sh
+++ b/scripts/build_dockerhub_image.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is used to create the docker image we push to dockerhub.
+# This requires that you have access to the dsluiuc dockerhub page. 
+# Currently, only Drake and Samarth have access to this.
+# Usage: sh scripts/build_dockerhub_image.sh
+
+docker login
+docker build . --target test-image --tag dsluiuc/honeybadgermpc-test-image
+docker push dsluiuc/honeybadgermpc-test-image:latest

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ REQUIRES_PYTHON = '>=3.7.0'
 VERSION = None
 
 REQUIRED = [
+    'cython',
     'gmpy2',
     'zfec',
     'pycrypto',
@@ -21,10 +22,9 @@ REQUIRED = [
     'pyzmq',
 ]
 
-TESTS_REQUIRES = [
-    'flake8',
+
+TEST_REQUIRES = [
     'pep8-naming',
-    'pytest',
     'pytest-asyncio',
     'pytest-mock',
     'pytest-cov',
@@ -32,33 +32,36 @@ TESTS_REQUIRES = [
     'pytest-xdist',
     'pytest-benchmark',
     'pytest-benchmark[histogram]',
-    'pyyaml',
 ]
 
 DEV_REQUIRES = [
     'ipdb',
-    'ipython',
 ]
 
-DOCS_REQUIRE = [
-    'Sphinx',
+DOCS_REQUIRES = [
     'sphinx-autobuild',
     'sphinx_rtd_theme',
     'sphinx_tabs',
     'm2r',
-    'doc8',
+    'doc8'
 ]
 
-ETH_REQUIRES = ['web3', 'ethereum']
+ETH_REQUIRES = [
+    'web3',
+    'ethereum',
+]
 
-AWS_REQUIRES = ['boto3', 'paramiko']
+AWS_REQUIRES = [
+    'boto3',
+    'paramiko',
+]
 
 EXTRAS = {
-    'tests': TESTS_REQUIRES,
-    'dev': DEV_REQUIRES + TESTS_REQUIRES + DOCS_REQUIRE + ETH_REQUIRES,
-    'docs': DOCS_REQUIRE + ETH_REQUIRES,
+    'tests': TEST_REQUIRES,
+    'dev': DEV_REQUIRES + TEST_REQUIRES + DOCS_REQUIRES + ETH_REQUIRES,
+    'docs': DOCS_REQUIRES + ETH_REQUIRES,
     'eth': ETH_REQUIRES,
-    'aws': AWS_REQUIRES,
+    'aws': AWS_REQUIRES
 }
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -99,7 +102,10 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     python_requires=REQUIRES_PYTHON,
-    setup_requires=['cffi>=1.0.0', 'Cython'],
+    setup_requires=[
+        'cffi>=1.0.0',
+        'cython'
+    ],
     install_requires=REQUIRED,
     cffi_modules=['apps/shuffle/solver/solver_build.py:ffibuilder'],
     extras_require=EXTRAS,


### PR DESCRIPTION
Currently, the docker image we use for testing is ~2.5 GB. This cuts the size down to ~550 MB, and also makes it so that we don't have to install dependencies on travis. This allows our CI/CD pipeline to finish around 7-8 minutes. However, this will require some manual processes when we update our dependencies-- someone will have to re-run the script to build and push the docker image to dockerhub.