### PR TITLE
Asynchromix coordinator using Ethereum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 #   - pbc
 #   - charm
 #   - base pip dependencies (cython & setup.py)
+#   - ethereum
 # 
 # Thereafter, it adds ever increasing levels of dependencies-- 
 #   - Test requirements (including doc requirements)
@@ -87,6 +88,25 @@ RUN git clone https://github.com/JHUISI/charm.git
 WORKDIR /charm/
 RUN git reset --hard be9587ccdd4d61c591fb50728ebf2a4690a2064f
 RUN ./configure.sh
+RUN make install
+WORKDIR /
+
+
+# Ethereum .[eth] extras
+RUN apt-get install -y --no-install-recommends \
+    git cmake g++ \
+    libffi-dev libssl-dev sudo
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN apt-get install -y --no-install-recommends nodejs npm
+RUN npm install -g ganache-cli
+RUN git clone --recursive https://github.com/ethereum/solidity.git
+WORKDIR /solidity/
+RUN git checkout v0.4.24 # Old version necessary to work???
+RUN git submodule update --init --recursive
+RUN ./scripts/install_deps.sh
+RUN mkdir build/
+WORKDIR build
+RUN cmake ..
 RUN make install
 WORKDIR /
 

--- a/apps/asynchromix/asynchromix.py
+++ b/apps/asynchromix/asynchromix.py
@@ -1,0 +1,518 @@
+"""
+Implementation of Asynchromix MPC Coordinator using an EVM blockchain
+"""
+from web3 import Web3, HTTPProvider
+import time
+import asyncio
+import logging
+from contextlib import contextmanager
+import subprocess
+from honeybadgermpc.router import SimpleRouter
+from honeybadgermpc.utils.misc import subscribe_recv, wrap_send
+from honeybadgermpc.utils.misc import print_exception_callback
+from honeybadgermpc.field import GF
+from honeybadgermpc.polynomial import EvalPoint, polynomials_over
+from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.offline_randousha import randousha
+from honeybadgermpc.offline_randousha import generate_triples
+from honeybadgermpc.offline_randousha import generate_bits
+from honeybadgermpc.mpc import Mpc
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
+from honeybadgermpc.progs.mixins.constants import MixinConstants
+from honeybadgermpc.progs.mixins.base import MixinBase
+from butterfly_network import iterated_butterfly_network
+from ethereum.tools._solidity import compile_code as compile_source
+from web3.contract import ConciseContract
+import os
+
+
+# For fake preprocessing
+from honeybadgermpc.preprocessing import (
+    PreProcessedElements, clear_preprocessing)
+
+field = GF(Subgroup.BLS12_381)
+
+
+async def wait_for_receipt(w3, tx_hash):
+    while True:
+        tx_receipt = w3.eth.getTransactionReceipt(tx_hash)
+        if tx_receipt is not None:
+            break
+        await asyncio.sleep(5)
+    return tx_receipt
+
+
+########
+# Client
+########
+
+class AsynchromixClient(object):
+    def __init__(self, sid, myid, send, recv, w3, contract, req_mask):
+        self.sid = sid
+        self.myid = myid
+        self.contract = contract
+        self.w3 = w3
+        self.req_mask = req_mask
+        self._task = asyncio.ensure_future(self._run())
+        self._task.add_done_callback(print_exception_callback)
+
+    async def _run(self):
+        contract_concise = ConciseContract(self.contract)
+        await asyncio.sleep(60)  # give the servers a head start
+        # Client sends several batches of messages then quits
+        for epoch in range(1000):
+            logging.info(f'[Client] Starting Epoch {epoch}')
+            receipts = []
+            for i in range(32):
+                m = f'message:{epoch}:{i}'
+                task = asyncio.ensure_future(self.send_message(m))
+                task.add_done_callback(print_exception_callback)
+                receipts.append(task)
+            receipts = await asyncio.gather(*receipts)
+
+            while True:  # wait before sending next
+                if contract_concise.outputs_ready() > epoch:
+                    break
+                await asyncio.sleep(5)
+
+    async def _get_inputmask(self, idx):
+        # Private reconstruct
+        contract_concise = ConciseContract(self.contract)
+        n = contract_concise.n()
+        poly = polynomials_over(field)
+        eval_point = EvalPoint(field, n, use_omega_powers=False)
+        shares = []
+        for i in range(n):
+            share = self.req_mask(i, idx)
+            shares.append(share)
+        shares = await asyncio.gather(*shares)
+        shares = [(eval_point(i), share) for i, share in enumerate(shares)]
+        mask = poly.interpolate_at(shares, 0)
+        return mask
+
+    async def join(self):
+        await self._task
+
+    async def send_message(self, m):
+        # Submit a message to be mixed
+        contract_concise = ConciseContract(self.contract)
+
+        # Step 1. Wait until there is input available, and enough triples
+        while True:
+            inputmasks_available = contract_concise.inputmasks_available()
+            # logging.infof'inputmasks_available: {inputmasks_available}')
+            if inputmasks_available >= 1:
+                break
+            await asyncio.sleep(5)
+
+        # Step 2. Reserve the input mask
+        tx_hash = self.contract.functions.reserve_inputmask().transact(
+            {'from': self.w3.eth.accounts[0]})
+        tx_receipt = await wait_for_receipt(self.w3, tx_hash)
+        rich_logs = self.contract.events.InputMaskClaimed().processReceipt(tx_receipt)
+        if rich_logs:
+            inputmask_idx = rich_logs[0]['args']['inputmask_idx']
+        else:
+            raise ValueError
+
+        # Step 3. Fetch the input mask from the servers
+        inputmask = await self._get_inputmask(inputmask_idx)
+        message = int.from_bytes(m.encode(), 'big')
+        maskedinput = message + inputmask
+        maskedinput_bytes = self.w3.toBytes(hexstr=hex(maskedinput.value))
+        maskedinput_bytes = maskedinput_bytes.rjust(32, b'\x00')
+
+        # Step 4. Publish the masked input
+        tx_hash = self.contract.functions.submit_message(
+            inputmask_idx, maskedinput_bytes).transact({'from': self.w3.eth.accounts[0]})
+        tx_receipt = await wait_for_receipt(self.w3, tx_hash)
+
+
+########
+# Server
+########
+
+class AsynchromixServer(object):
+    def __init__(self, sid, myid, send, recv, w3, contract):
+        self.sid = sid
+        self.myid = myid
+        self.contract = contract
+        self.w3 = w3
+        self._task1a = asyncio.ensure_future(self._offline_inputmasks_loop())
+        self._task1a.add_done_callback(print_exception_callback)
+        self._task1b = asyncio.ensure_future(self._offline_mixes_loop())
+        self._task1b.add_done_callback(print_exception_callback)
+        self._task2 = asyncio.ensure_future(self._client_request_loop())
+        self._task2.add_done_callback(print_exception_callback)
+        self._task3 = asyncio.ensure_future(self._mixing_loop())
+        self._task3.add_done_callback(print_exception_callback)
+        self._task4 = asyncio.ensure_future(self._mixing_initiate_loop())
+        self._task4.add_done_callback(print_exception_callback)
+
+        self._subscribe_task, subscribe = subscribe_recv(recv)
+
+        def _get_send_recv(tag):
+            return wrap_send(tag, send), subscribe(tag)
+        self.get_send_recv = _get_send_recv
+
+        self._inputmasks = []
+        self._triples = []
+        self._bits = []
+
+    async def join(self):
+        await self._task1a
+        await self._task1b
+        await self._task2
+        await self._task3
+        await self._task4
+        await self._subscribe_task
+
+    #######################
+    # Step 1. Offline Phase
+    #######################
+    """
+    1a. offline mixes (bits and triples)
+    1b. offline inputmasks
+    The bits and triples are consumed by each mixing epoch.
+
+    The input masks may be claimed at a different rate than
+    than the mixing epochs so they are replenished in a separate
+    task
+    """
+
+    async def _preprocess_report(self):
+        # Submit the preprocessing report
+        tx_hash = self.contract.functions.preprocess_report([
+            len(self._triples),
+            len(self._bits),
+            len(self._inputmasks)]).transact({'from': self.w3.eth.accounts[self.myid]})
+
+        # Wait for the tx receipt
+        tx_receipt = await wait_for_receipt(self.w3, tx_hash)
+        return tx_receipt
+
+    async def _offline_mixes_loop(self):
+        contract_concise = ConciseContract(self.contract)
+        n = contract_concise.n()
+        t = contract_concise.t()
+        preproc_round = 0
+        PER_MIX_TRIPLES = contract_concise.PER_MIX_TRIPLES()  # noqa: N806
+        PER_MIX_BITS = contract_concise.PER_MIX_BITS()  # noqa: N806
+
+        # Start up:
+        await self._preprocess_report()
+
+        while True:
+            # Step 1a. I) Wait for more triples/bits to be needed
+            while True:
+                mixes_available = contract_concise.mixes_available()
+
+                # Policy: try to maintain a buffer of mixes
+                target = 10
+                if mixes_available < target:
+                    break
+                # already have enough triples/bits, sleep
+                await asyncio.sleep(5)
+
+            # Step 1a. II) Run generate triples and generate_bits
+            logging.info(
+                f'[{self.myid}] mixes available: {mixes_available} \
+                   target: {target}')
+            logging.info(f'[{self.myid}] Initiating Triples {PER_MIX_TRIPLES}')
+            send, recv = self.get_send_recv(
+                f'preproc:mixes:triples:{preproc_round}')
+            start_time = time.time()
+            triples = await generate_triples(n, t, PER_MIX_TRIPLES,
+                                             self.myid, send, recv, field)
+            end_time = time.time()
+            logging.info(
+                f"[{self.myid}] Triples finished in {end_time-start_time}")
+
+            # Bits
+            logging.info(f'[{self.myid}] Initiating Bits {PER_MIX_BITS}')
+            send, recv = self.get_send_recv(
+                f'preproc:mixes:bits:{preproc_round}')
+            start_time = time.time()
+            bits = await generate_bits(n, t, PER_MIX_BITS,
+                                       self.myid, send, recv, field)
+            end_time = time.time()
+            logging.info(
+                f"[{self.myid}] Bits finished in {end_time-start_time}")
+
+            # Append each triple
+            self._triples += triples
+            self._bits += bits
+
+            # Step 1a. III) Submit an updated report
+            await self._preprocess_report()
+
+            # Increment the preprocessing round and continue
+            preproc_round += 1
+
+    async def _offline_inputmasks_loop(self):
+        contract_concise = ConciseContract(self.contract)
+        n = contract_concise.n()
+        t = contract_concise.t()
+        K = contract_concise.K()  # noqa: N806
+        preproc_round = 0
+        k = K // (n - 2 * t)  # batch size
+        while True:
+            # Step 1b. I) Wait until needed
+            while True:
+                inputmasks_available = contract_concise.inputmasks_available()
+                totalmasks = contract_concise.preprocess()[2]
+                # Policy: try to maintain a buffer of 10 * K input masks
+                target = 10 * K
+                if inputmasks_available < target:
+                    break
+                # already have enough input masks, sleep
+                await asyncio.sleep(5)
+
+            # Step 1b. II) Run Randousha
+            logging.info(
+                f'[{self.myid}] totalmasks: {totalmasks} \
+                inputmasks available: {inputmasks_available} \
+                target: {target} Initiating Randousha {k * (n - 2*t)}')
+            send, recv = self.get_send_recv(
+                f'preproc:inputmasks:{preproc_round}')
+            start_time = time.time()
+            rs_t, rs_2t = zip(*await randousha(n, t, k, self.myid, send, recv, field))
+            assert len(rs_t) == len(rs_2t) == k * (n - 2 * t)
+
+            # Note: here we just discard the rs_2t
+            # In principle both sides of randousha could be used with
+            # a small modification to randousha
+            end_time = time.time()
+            logging.info(
+                f"[{self.myid}] Randousha finished in {end_time-start_time}")
+            self._inputmasks += rs_t
+
+            # Step 1b. III) Submit an updated report
+            await self._preprocess_report()
+
+            # Increment the preprocessing round and continue
+            preproc_round += 1
+
+    async def _client_request_loop(self):
+        # Task 2. Handling client input
+        # TODO: if a client requests a share,
+        # check if it is authorized and if so send it along
+        pass
+
+    async def _mixing_loop(self):
+        # Task 3. Participating in mixing epochs
+        contract_concise = ConciseContract(self.contract)
+        n = contract_concise.n()
+        t = contract_concise.t()
+        K = contract_concise.K()  # noqa: N806
+        PER_MIX_TRIPLES = contract_concise.PER_MIX_TRIPLES()  # noqa: N806
+        PER_MIX_BITS = contract_concise.PER_MIX_BITS()  # noqa: N806
+
+        epoch = 0
+        while True:
+            # 3.a. Wait for the next mix to be initiated
+            while True:
+                epochs_initiated = contract_concise.epochs_initiated()
+                if epochs_initiated > epoch:
+                    break
+                await asyncio.sleep(5)
+
+            # 3.b. Collect the inputs
+            inputs = []
+            for idx in range(epoch * K, (epoch + 1) * K):
+                # Get the public input
+                masked_input, inputmask_idx = contract_concise.input_queue(idx)
+                masked_input = field(int.from_bytes(masked_input, 'big'))
+                # Get the input masks
+                inputmask = self._inputmasks[inputmask_idx]
+
+                m_share = masked_input - inputmask
+                inputs.append(m_share)
+
+            # 3.c. Collect the preprocessing
+            triples = self._triples[(epoch+0)*PER_MIX_TRIPLES:
+                                    (epoch+1)*PER_MIX_TRIPLES]
+            bits = self._bits[(epoch+0)*PER_MIX_BITS:
+                              (epoch+1)*PER_MIX_BITS]
+
+            # Hack explanation... the relevant mixins are in triples
+            key = (self.myid, n, t)
+            if key in MixinBase.pp_elements._triples:
+                del MixinBase.pp_elements._triples[key]
+            if key in MixinBase.pp_elements._bits:
+                del MixinBase.pp_elements._bits[key]
+
+            # 3.d. Call the MPC program
+            async def prog(ctx):
+                # Overwrite the triples
+                MixinBase.pp_elements.write_triples(ctx, triples)
+                MixinBase.pp_elements.write_one_minus_one(ctx, bits)
+                logging.info(f"[{ctx.myid}] Running permutation network")
+                inps = list(map(ctx.Share, inputs))
+                assert len(inps) == K
+                shuffled = await iterated_butterfly_network(ctx, inps, K)
+                shuffled_shares = ctx.ShareArray(
+                    list(map(ctx.Share, shuffled)))
+                opened_values = await shuffled_shares.open()
+                msgs = [m.value.to_bytes(32, 'big').decode().strip('\x00')
+                        for m in opened_values]
+                return msgs
+
+            send, recv = self.get_send_recv(f'mpc:{epoch}')
+            logging.info(f'[{self.myid}] MPC initiated:{epoch}')
+
+            # Config just has to specify mixins used by switching_network
+            config = {MixinConstants.MultiplyShareArray: BeaverMultiplyArrays()}
+
+            ctx = Mpc(f'mpc:{epoch}', n, t, self.myid, send, recv,
+                      prog, config)
+            result = await ctx._run()
+            logging.info(f'[{self.myid}] MPC complete {result}')
+
+            # 3.e. Output the published messages to contract
+            result = ','.join(result)
+            tx_hash = self.contract.functions.propose_output(epoch, result) \
+                .transact({'from': self.w3.eth.accounts[self.myid]})
+            tx_receipt = await wait_for_receipt(self.w3, tx_hash)
+            rich_logs = self.contract.events.MixOutput() \
+                                            .processReceipt(tx_receipt)
+            if rich_logs:
+                epoch = rich_logs[0]['args']['epoch']
+                output = rich_logs[0]['args']['output']
+                logging.info(f'[{self.myid}] MIX OUTPUT[{epoch}] {output}')
+            else:
+                pass
+
+            epoch += 1
+
+        pass
+
+    async def _mixing_initiate_loop(self):
+        # Task 4. Initiate mixing epochs
+        contract_concise = ConciseContract(self.contract)
+        K = contract_concise.K()  # noqa: N806
+        while True:
+            # Step 4.a. Wait until there are k values then call initiate_mix
+            while True:
+                inputs_ready = contract_concise.inputs_ready()
+                mixes_avail = contract_concise.mixes_available()
+                if inputs_ready >= K and mixes_avail >= 1:
+                    break
+                await asyncio.sleep(5)
+
+            # Step 4.b. Call initiate mix
+            tx_hash = self.contract.functions.initiate_mix().transact(
+                {'from': self.w3.eth.accounts[0]})
+            tx_receipt = await wait_for_receipt(self.w3, tx_hash)
+            rich_logs = self.contract.events.MixingEpochInitiated() \
+                                            .processReceipt(tx_receipt)
+            if rich_logs:
+                epoch = rich_logs[0]['args']['epoch']
+                logging.info(f'[{self.myid}] Mixing epoch initiated: {epoch}')
+            else:
+                logging.info(f'[{self.myid}] initiate_mix failed (redundant?)')
+            await asyncio.sleep(10)
+
+
+###############
+# Ganache test
+###############
+
+async def main_loop(w3):
+
+    # deletes sharedata/ if present
+    clear_preprocessing()
+    PreProcessedElements()._create_sharedata_dir_if_not_exists()
+
+    # Step 1.
+    # Create the coordinator contract and web3 interface to it
+    compiled_sol = compile_source(open(os.path.join(os.path.dirname(
+        __file__), 'asynchromix.sol')).read())  # Compiled source code
+    contract_interface = compiled_sol['<stdin>:AsynchromixCoordinator']
+    contract_class = w3.eth.contract(abi=contract_interface['abi'],
+                                     bytecode=contract_interface['bin'])
+    # tx_hash = contract_class.constructor(w3.eth.accounts[:7],2).transact(
+    #   {'from':w3.eth.accounts[0]})  # n=7, t=2
+
+    tx_hash = contract_class.constructor(w3.eth.accounts[:4], 1).transact(
+        {'from': w3.eth.accounts[0]})  # n=4, t=1
+
+    # Get tx receipt to get contract address
+    tx_receipt = await wait_for_receipt(w3, tx_hash)
+    contract_address = tx_receipt['contractAddress']
+
+    if w3.eth.getCode(contract_address) == b'':
+        logging.critical('code was empty 0x, constructor may have run out of gas')
+        raise ValueError
+
+    # Contract instance in concise mode
+    abi = contract_interface['abi']
+    contract = w3.eth.contract(address=contract_address, abi=abi)
+    contract_concise = ConciseContract(contract)
+
+    # Call read only methods to check
+    n = contract_concise.n()
+
+    # Step 2: Create the servers
+    router = SimpleRouter(n)
+    sends, recvs = router.sends, router.recvs
+    servers = [AsynchromixServer('sid', i, sends[i], recvs[i], w3, contract)
+               for i in range(n)]
+
+    # Step 3. Create the client
+    async def req_mask(i, idx):
+        # client requests input mask {idx} from server {i}
+        return servers[i]._inputmasks[idx]
+
+    client = AsynchromixClient('sid', 'client', None, None,
+                               w3, contract, req_mask)
+
+    # Step 4. Wait for conclusion
+    for i, server in enumerate(servers):
+        await server.join()
+    await client.join()
+
+
+@contextmanager
+def run_and_terminate_process(*args, **kwargs):
+    try:
+        p = subprocess.Popen(*args, **kwargs)
+        yield p
+    finally:
+        logging.info("Killing ganache-cli", p.pid)
+        p.terminate()  # send sigterm, or ...
+        p.kill()      # send sigkill
+        p.wait()
+        logging.info('done')
+
+
+def run_eth():
+    w3 = Web3(HTTPProvider())  # Connect to localhost:8545
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    loop = asyncio.get_event_loop()
+    try:
+        logging.info('entering loop')
+        loop.run_until_complete(
+            asyncio.gather(
+                main_loop(w3),
+            ))
+    finally:
+        logging.info('closing')
+        loop.close()
+
+
+def test_asynchromix():
+    import time
+    # cmd = 'testrpc -a 50 2>&1 | tee -a acctKeys.json'
+    # with run_and_terminate_process(cmd, shell=True,
+    # stdout=sys.stdout, stderr=sys.stderr) as proc:
+    cmd = "ganache-cli -p 8545 -a 50 -b 1 > acctKeys.json 2>&1"
+    logging.info("Running", cmd)
+    with run_and_terminate_process(cmd, shell=True):
+        time.sleep(5)
+        run_eth()
+
+
+if __name__ == '__main__':
+    # Launch an ethereum test chain
+    test_asynchromix()

--- a/apps/asynchromix/asynchromix.sol
+++ b/apps/asynchromix/asynchromix.sol
@@ -1,0 +1,252 @@
+pragma solidity >=0.4.22 <0.6.0;
+
+contract AsynchromixCoordinator {
+    /* A blockchain-based MPC coordinator for Asychromix.
+     * 1. Keeps track of the MPC "preprocessing buffer"
+     * 2. Accepts client input 
+     *      (makes use of preprocess randoms)
+     * 3. Initiates mixing epochs (MPC computations)
+     *      (makes use of preprocess triples, bits, powers)
+     */
+     
+    // Session parameters
+    uint public n;
+    uint public t;
+    address[] public servers;
+    mapping (address => uint) public servermap;
+    
+    constructor(address[] _servers, uint _t) public {
+	    n = _servers.length;
+	    t  = _t;
+	    require(3*t < n);
+	    servers.length = n;
+	    for (uint i = 0; i < n; i++) {
+	        servers[i] = _servers[i];
+    	    servermap[_servers[i]] = i+1; // servermap is off-by-one
+    	}
+    }
+   /*
+    * It's necessary to paste JSON into the "_servers" constructor to use the Remix IDE
+    * Copy and paste the following for n=4:
+["0xca35b7d915458ef540ade6068dfe2f44e8fa733c",
+ "0xca35b7d915458ef540ade6068dfe2f44e8fa733c",
+ "0xca35b7d915458ef540ade6068dfe2f44e8fa733c",
+ "0xca35b7d915458ef540ade6068dfe2f44e8fa733c"]
+    *
+    */
+    
+    // ###############################################
+    // 1. Preprocessing Buffer (the MPC offline phase)
+    // ###############################################
+
+    struct PreProcessCount {
+        uint triples;        // [a],[b],[ab]
+        uint bits;           // [b] with b in {-1,1}
+        uint inputmasks;     // [r]
+    }
+    
+    // Consensus count (min of the player report counts)
+    PreProcessCount public preprocess;
+    
+    // How many of each have been reserved already
+    PreProcessCount public preprocess_used;
+
+    function inputmasks_available () public view returns(uint) {
+        return preprocess.inputmasks - preprocess_used.inputmasks;
+    }    
+
+    // Report of preprocess buffer size from each server
+    mapping ( uint => PreProcessCount ) public preprocess_reports;
+    
+    event PreProcessUpdated();
+    
+    function min(uint a, uint b) private pure returns (uint) {
+        return a < b ? a : b;
+    }    
+    
+    function max(uint a, uint b) private pure returns (uint) {
+        return a > b ? a : b;
+    }
+
+    function preprocess_report(uint[3] rep) public {
+        // Update the Report 
+        require(servermap[msg.sender] > 0);   // only valid servers
+        uint id = servermap[msg.sender] - 1;
+        preprocess_reports[id].triples    = rep[0];
+        preprocess_reports[id].bits       = rep[1];
+        preprocess_reports[id].inputmasks = rep[2];
+
+        // Update the consensus
+        // .triples = min (over each id) of _reports[id].triples; same for bits, etc. 
+        PreProcessCount memory mins;
+        mins.triples    = preprocess_reports[0].triples;
+        mins.bits       = preprocess_reports[0].bits;
+        mins.inputmasks = preprocess_reports[0].inputmasks;
+        for (uint i = 1; i < n; i++) {
+            mins.triples    = min(mins.triples,    preprocess_reports[i].triples);
+            mins.bits       = min(mins.bits,       preprocess_reports[i].bits);
+            mins.inputmasks = min(mins.inputmasks, preprocess_reports[i].inputmasks);
+        }
+        if (preprocess.triples    < mins.triples ||
+            preprocess.bits       < mins.bits    ||
+            preprocess.inputmasks < mins.inputmasks) {
+            emit PreProcessUpdated();
+        }
+        preprocess.triples    = mins.triples;
+        preprocess.bits       = mins.bits;
+        preprocess.inputmasks = mins.inputmasks;
+    }
+    
+    
+    
+    // ######################
+    // 2. Accept client input 
+    // ######################
+    
+    // Step 2.a. Clients can reserve an input mask [r] from Preprocessing
+
+    // maps each element of preprocess.inputmasks to the client (if any) that claims it
+    mapping (uint => address) public inputmasks_claimed;
+    
+    event InputMaskClaimed(address client, uint inputmask_idx);
+    
+    // Client reserves a random values
+    function reserve_inputmask() public returns(uint) {
+        // Extension point: override this function to add custom token rules
+        
+        // An unclaimed input mask must already be available
+        require(preprocess.inputmasks > preprocess_used.inputmasks);
+        
+        // Acquire this input mask for msg.sender
+        uint idx = preprocess_used.inputmasks;
+        inputmasks_claimed[idx] = msg.sender;
+        preprocess_used.inputmasks += 1;
+        emit InputMaskClaimed(msg.sender, idx);
+        return idx;
+    }
+    
+    // Step 2.b. Client requests (out of band, e.g. over https) shares of [r]
+    //           from each server. Servers use this function to check authorization.
+    //           Authentication using client's address is also out of band
+    function client_authorized(address client, uint idx) view public returns(bool) {
+        return inputmasks_claimed[idx] == client;
+    }
+    
+    // Step 2.c. Clients publish masked message (m+r) to provide a new input [m]
+    //           and bind it to the preprocess input
+    mapping (uint => bool) public inputmask_map; // Maps a mask 
+    
+    struct Input {
+        bytes32 masked_input; // (m+r)
+        uint inputmask;       // index in inputmask of mask [r]
+
+        // Extension point: add more metadata about each input
+    }
+    
+    Input[] public input_queue; // All inputs sent so far
+    function input_queue_length() public view returns(uint) {
+        return input_queue.length;
+    }
+    
+    event MessageSubmitted(uint idx, uint inputmask_idx, bytes32 masked_input);
+
+    function submit_message(uint inputmask_idx, bytes32 masked_input) public {
+        // Must be authorized to use this input mask
+        require(inputmasks_claimed[inputmask_idx] == msg.sender);
+        
+        // Extension point: add additional client authorizations,
+        //  e.g. prevent the client from submitting more than one message per mix
+        
+        uint idx = input_queue.length;
+        input_queue.length += 1;
+        
+        input_queue[idx].masked_input = masked_input;
+        input_queue[idx].inputmask = inputmask_idx;
+        
+        emit MessageSubmitted(idx, inputmask_idx, masked_input);
+
+        // The input masks are deactivated after first use
+        inputmasks_claimed[inputmask_idx] = address(0);
+    }
+    
+    // #########################
+    // 3. Initiate Mixing Epochs
+    // #########################
+    
+    uint public constant K = 32; // Mix Size 
+    
+    // Preprocessing requirements
+    uint public constant PER_MIX_TRIPLES = (K / 2) * 5 * 5; // k log^2 k
+    uint public constant PER_MIX_BITS    = (K / 2) * 5 * 5;
+
+    // Return the maximum number of mixes that can be run with the
+    // available preprocessing
+    function mixes_available() public view returns(uint) {
+        uint triples_available = preprocess.triples - preprocess_used.triples;
+        uint bits_available    = preprocess.bits    - preprocess_used.bits;
+        return min(triples_available / PER_MIX_TRIPLES,
+                   bits_available    / PER_MIX_BITS);
+    }
+    
+    // Step 3.a. Trigger a mix to start
+    uint public inputs_mixed;
+    uint public epochs_initiated;
+    event MixingEpochInitiated(uint epoch);
+
+    function inputs_ready() public view returns(uint) {
+        return input_queue.length - inputs_mixed;
+    }
+    
+    function initiate_mix() public {
+        // Must mix eactly K values in each epoch
+        require(input_queue.length >= inputs_mixed + K);
+        
+        // Can only initiate mix if enough preprocessings are ready
+        require(preprocess.triples >= preprocess_used.triples + PER_MIX_TRIPLES);
+        require(preprocess.bits    >= preprocess_used.bits    + PER_MIX_BITS);
+        preprocess_used.triples += PER_MIX_TRIPLES;
+        preprocess_used.bits    += PER_MIX_BITS;
+        
+        inputs_mixed += K;
+        emit MixingEpochInitiated(epochs_initiated);
+        epochs_initiated += 1;
+        output_votes.length = epochs_initiated;
+        output_hashes.length = epochs_initiated;
+    }
+    
+    // Step 3.b. Output reporting: the output is considered "approved" once
+    //           at least t+1 servers report it 
+    
+    uint public outputs_ready;
+    event MixOutput(uint epoch, string output);
+    bytes32[] public output_hashes;
+    uint[] public output_votes;
+    mapping (uint => uint) public server_voted; // highest epoch voted in
+
+    function propose_output(uint epoch, string output) public {
+        require(epoch < epochs_initiated);    // can't provide output if it hasn't been initiated
+        require(servermap[msg.sender] > 0);   // only valid servers
+        uint id = servermap[msg.sender] - 1;
+
+        // Each server can only vote once per epoch
+        // Hazard note: honest servers must vote in strict ascending order, or votes
+        //              will be lost!
+        require(epoch <= server_voted[id]);
+        server_voted[id] = max(epoch + 1, server_voted[id]);
+
+        bytes32 output_hash = sha3(output);
+
+        if (output_votes[epoch] > 0) {
+            // All the votes must match
+            require(output_hash == output_hashes[epoch]);
+        } else {
+            output_hashes[epoch] = output_hash;
+        }
+        
+        output_votes[epoch] += 1;
+        if (output_votes[epoch] == t + 1) {    // at least one honest node agrees
+            emit MixOutput(epoch, output);
+            outputs_ready += 1;
+        }
+    }
+}

--- a/apps/asynchromix/butterfly_network.py
+++ b/apps/asynchromix/butterfly_network.py
@@ -9,8 +9,9 @@ from time import time
 async def batch_switch(ctx, xs, ys, n):
     pp_elements = PreProcessedElements()
     sbits = [pp_elements.get_one_minus_one_rand(ctx).v for _ in range(n//2)]
-    ns = [1 / ctx.field(2) for _ in range(n)]
+    ns = [1 / ctx.field(2) for _ in range(n//2)]
 
+    assert len(xs) == len(ys) == len(sbits) == n // 2
     xs, ys, sbits = list(map(ctx.ShareArray, [xs, ys, sbits]))
     ms = (await (sbits * (xs - ys)))._shares
 

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -25,6 +25,25 @@ class PreProcessingConstants(object):
     SHARE_BITS_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}share_bits"
 
 
+async def wait_for_preprocessing():
+    while not os.path.exists(f"{PreProcessingConstants.SHARED_DATA_DIR}READY"):
+        logging.info(
+            f"waiting for preprocessing {PreProcessingConstants.READY_FILE_NAME}")
+        await asyncio.sleep(1)
+
+
+def clear_preprocessing():
+    import shutil
+    try:
+        shutil.rmtree(f"{PreProcessingConstants.SHARED_DATA_DIR}")
+    except FileNotFoundError:
+        pass  # not a problem
+
+
+def preprocessing_done():
+    os.mknod(PreProcessingConstants.READY_FILE_NAME)
+
+
 class PreProcessedElements(object):
     def __init__(self):
         self.field = GF(Subgroup.BLS12_381)
@@ -91,6 +110,141 @@ class PreProcessedElements(object):
 
         f.write(content)
 
+    def _create_sharedata_dir_if_not_exists(self):
+        makedirs(PreProcessingConstants.SHARED_DATA_DIR, exist_ok=True)
+
+    ##############################
+    # MPC program access to shares
+    ##############################
+
+    def get_triple(self, ctx):
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._triples:
+            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+            file_path = f"{PreProcessingConstants.TRIPLES_FILE_NAME_PREFIX}{file_suffix}"
+            self._triples[key] = iter(self._read_share_values_from_file(file_path))
+        try:
+            a = ctx.Share(next(self._triples[key]))
+            b = ctx.Share(next(self._triples[key]))
+            ab = ctx.Share(next(self._triples[key]))
+            return a, b, ab
+        except StopIteration:
+            print('STOP ITERATION TRIPLES')
+            raise StopIteration(f"preprocess underrun: TRIPLES")
+
+    def get_cube(self, ctx):
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._cubes:
+            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+            file_path = f"{PreProcessingConstants.CUBES_FILE_NAME_PREFIX}{file_suffix}"
+            self._cubes[key] = iter(self._read_share_values_from_file(file_path))
+        a1 = ctx.Share(next(self._cubes[key]))
+        a2 = ctx.Share(next(self._cubes[key]))
+        a3 = ctx.Share(next(self._cubes[key]))
+        return a1, a2, a3
+
+    def get_zero(self, ctx):
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._zeros:
+            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+            file_path = f"{PreProcessingConstants.ZEROS_FILE_NAME_PREFIX}{file_suffix}"
+            self._zeros[key] = iter(self._read_share_values_from_file(file_path))
+        return ctx.Share(next(self._zeros[key]))
+
+    def get_rand(self, ctx, t=None):
+        t = t if t is not None else ctx.t
+        key = (ctx.myid, ctx.N, t)
+        if key not in self._rands:
+            file_suffix = f"_{ctx.N}_{t}-{ctx.myid}.share"
+            file_path = f"{PreProcessingConstants.RANDS_FILE_NAME_PREFIX}{file_suffix}"
+            self._rands[key] = iter(self._read_share_values_from_file(file_path))
+        return ctx.Share(next(self._rands[key]), t)
+
+    def get_bit(self, ctx):
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._bits:
+            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+            file_path = f"{PreProcessingConstants.BITS_FILE_NAME_PREFIX}{file_suffix}"
+            self._bits[key] = iter(self._read_share_values_from_file(file_path))
+        return ctx.Share(next(self._bits[key]))
+
+    def get_one_minus_one_rand(self, ctx):
+        file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+        fpath = f"{PreProcessingConstants.ONE_MINUS_ONE_FILE_NAME_PREFIX}{file_suffix}"
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._one_minus_one_rands:
+            self._one_minus_one_rands[key] = iter(
+                self._read_share_values_from_file(fpath))
+        try:
+            return ctx.Share(next(self._one_minus_one_rands[key]))
+        except StopIteration:
+            print('STOP ITERATION ONE_MINUS_ONE')
+            raise StopIteration(f"preprocess underrun: ONE_MINUS_ONE")
+
+    def get_powers(self, ctx, pid):
+        file_suffix = f"_{pid}_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+        return list(map(ctx.Share, self._read_share_values_from_file(
+            f"{PreProcessingConstants.POWERS_FILE_NAME_PREFIX}{file_suffix}")))
+
+    def get_share(self, ctx, sid, t=None):
+        if t is None:
+            t = ctx.t
+        file_suffix = f"_{sid}_{ctx.N}_{t}-{ctx.myid}.share"
+        share_values = self._read_share_values_from_file(
+            f"{PreProcessingConstants.SHARES_FILE_NAME_PREFIX}{file_suffix}")
+        return ctx.Share(share_values[0], t)
+
+    def get_double_share(self, ctx):
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._double_shares:
+            suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+            path = f"{PreProcessingConstants.DOUBLE_SHARES_FILE_NAME_PREFIX}{suffix}"
+            self._double_shares[key] = iter(self._read_share_values_from_file(path))
+        r_t = ctx.Share(next(self._double_shares[key]))
+        r_2t = ctx.Share(next(self._double_shares[key]), 2*ctx.t)
+        return r_t, r_2t
+
+    def get_share_bits(self, ctx):
+        key = (ctx.myid, ctx.N, ctx.t)
+        if key not in self._share_bits:
+            suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
+            path = f"{PreProcessingConstants.SHARE_BITS_FILE_NAME_PREFIX}{suffix}"
+            self._share_bits[key] = iter(self._read_share_bit_values_from_file(path))
+
+        share_val, bit_vals = next(self._share_bits[key])
+        share = ctx.Share(share_val)
+        bits = [ctx.Share(val) for val in bit_vals]
+
+        return share, bits
+
+    #########################
+    # Store the Preprocessing
+    #########################
+
+    def write_shares(self, ctx, file_name_prefix, degree, shares):
+        with open('%s_%d_%d-%d.share' % (file_name_prefix,
+                                         ctx.N, ctx.t, ctx.myid), 'w') as f:
+            self._write_shares_to_file(f, degree, ctx.myid, shares)
+
+    def write_triples(self, ctx, triples):
+        trips = []
+        for a, b, ab in triples:
+            trips += (a, b, ab)
+        prefix = PreProcessingConstants.TRIPLES_FILE_NAME_PREFIX
+        self.write_shares(ctx, prefix, ctx.t, trips)
+
+    def write_one_minus_one(self, ctx, shares):
+        prefix = PreProcessingConstants.ONE_MINUS_ONE_FILE_NAME_PREFIX
+        self.write_shares(ctx, prefix, ctx.t, shares)
+
+    ####################
+    # Fake Preprocessing
+    ####################
+    """
+    Only use generate_{preproctype} to create fake preprocessing,
+    useful for local experiments for just the online phase.
+    """
+
     def _write_polys(self, file_name_prefix, n, t, polys):
         polys = [[coeff.value for coeff in poly.coeffs] for poly in polys]
         all_shares = vandermonde_batch_evaluate(
@@ -100,9 +254,6 @@ class PreProcessedElements(object):
             # with open(f'{file_name_prefix}_{n}_{t}_{i}.share', 'w') as f:
             with open('%s_%d_%d-%d.share' % (file_name_prefix, n, t, i), 'w') as f:
                 self._write_shares_to_file(f, t, i, shares)
-
-    def _create_sharedata_dir_if_not_exists(self):
-        makedirs(PreProcessingConstants.SHARED_DATA_DIR, exist_ok=True)
 
     def generate_triples(self, k, n, t):
         self._create_sharedata_dir_if_not_exists()
@@ -203,106 +354,3 @@ class PreProcessedElements(object):
 
         self._write_polys(
             PreProcessingConstants.SHARE_BITS_FILE_NAME_PREFIX, n, t, polys)
-
-    def get_triple(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._triples:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.TRIPLES_FILE_NAME_PREFIX}{file_suffix}"
-            self._triples[key] = iter(self._read_share_values_from_file(file_path))
-        a = ctx.Share(next(self._triples[key]))
-        b = ctx.Share(next(self._triples[key]))
-        ab = ctx.Share(next(self._triples[key]))
-        return a, b, ab
-
-    def get_cube(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._cubes:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.CUBES_FILE_NAME_PREFIX}{file_suffix}"
-            self._cubes[key] = iter(self._read_share_values_from_file(file_path))
-        a1 = ctx.Share(next(self._cubes[key]))
-        a2 = ctx.Share(next(self._cubes[key]))
-        a3 = ctx.Share(next(self._cubes[key]))
-        return a1, a2, a3
-
-    def get_zero(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._zeros:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.ZEROS_FILE_NAME_PREFIX}{file_suffix}"
-            self._zeros[key] = iter(self._read_share_values_from_file(file_path))
-        return ctx.Share(next(self._zeros[key]))
-
-    def get_rand(self, ctx, t=None):
-        t = t if t is not None else ctx.t
-        key = (ctx.myid, ctx.N, t)
-        if key not in self._rands:
-            file_suffix = f"_{ctx.N}_{t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.RANDS_FILE_NAME_PREFIX}{file_suffix}"
-            self._rands[key] = iter(self._read_share_values_from_file(file_path))
-        return ctx.Share(next(self._rands[key]), t)
-
-    def get_bit(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._bits:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.BITS_FILE_NAME_PREFIX}{file_suffix}"
-            self._bits[key] = iter(self._read_share_values_from_file(file_path))
-        return ctx.Share(next(self._bits[key]))
-
-    def get_one_minus_one_rand(self, ctx):
-        file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-        fpath = f"{PreProcessingConstants.ONE_MINUS_ONE_FILE_NAME_PREFIX}{file_suffix}"
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._one_minus_one_rands:
-            self._one_minus_one_rands[key] = iter(
-                self._read_share_values_from_file(fpath))
-        return ctx.Share(next(self._one_minus_one_rands[key]))
-
-    def get_powers(self, ctx, pid):
-        file_suffix = f"_{pid}_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-        return list(map(ctx.Share, self._read_share_values_from_file(
-            f"{PreProcessingConstants.POWERS_FILE_NAME_PREFIX}{file_suffix}")))
-
-    def get_share(self, ctx, sid, t=None):
-        if t is None:
-            t = ctx.t
-        file_suffix = f"_{sid}_{ctx.N}_{t}-{ctx.myid}.share"
-        share_values = self._read_share_values_from_file(
-            f"{PreProcessingConstants.SHARES_FILE_NAME_PREFIX}{file_suffix}")
-        return ctx.Share(share_values[0], t)
-
-    def get_double_share(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._double_shares:
-            suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            path = f"{PreProcessingConstants.DOUBLE_SHARES_FILE_NAME_PREFIX}{suffix}"
-            self._double_shares[key] = iter(self._read_share_values_from_file(path))
-        r_t = ctx.Share(next(self._double_shares[key]))
-        r_2t = ctx.Share(next(self._double_shares[key]), 2*ctx.t)
-        return r_t, r_2t
-
-    def get_share_bits(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._share_bits:
-            suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            path = f"{PreProcessingConstants.SHARE_BITS_FILE_NAME_PREFIX}{suffix}"
-            self._share_bits[key] = iter(self._read_share_bit_values_from_file(path))
-
-        share_val, bit_vals = next(self._share_bits[key])
-        share = ctx.Share(share_val)
-        bits = [ctx.Share(val) for val in bit_vals]
-
-        return share, bits
-
-
-async def wait_for_preprocessing():
-    while not os.path.exists(f"{PreProcessingConstants.SHARED_DATA_DIR}READY"):
-        logging.info(
-            f"waiting for preprocessing {PreProcessingConstants.READY_FILE_NAME}")
-        await asyncio.sleep(1)
-
-
-def preprocessing_done():
-    os.mknod(PreProcessingConstants.READY_FILE_NAME)

--- a/honeybadgermpc/utils/misc.py
+++ b/honeybadgermpc/utils/misc.py
@@ -3,6 +3,15 @@ from collections import defaultdict
 from asyncio import Queue
 import asyncio
 from typing import Callable
+import logging
+
+
+def print_exception_callback(future):
+    if future.done():
+        ex = future.exception()
+        if ex is not None:
+            logging.critical('\nException:', future, type(ex), ex)
+            raise ex
 
 
 @TypeCheck()

--- a/tests/test_hbavss.py
+++ b/tests/test_hbavss.py
@@ -8,6 +8,7 @@ from honeybadgermpc.betterpairing import G1, ZR
 from honeybadgermpc.hbavss import HbAvssLight, HbAvssBatch
 from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.symmetric_crypto import SymmetricCrypto
+from honeybadgermpc.utils.misc import print_exception_callback
 import asyncio
 
 
@@ -22,12 +23,6 @@ def get_avss_params(n, t):
 
 @mark.asyncio
 async def test_hbavss_light(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
     t = 2
     n = 3*t + 1
 
@@ -49,7 +44,7 @@ async def test_hbavss_light(test_router):
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
         # shares = await asyncio.gather(*avss_tasks)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
@@ -63,13 +58,6 @@ async def test_hbavss_light(test_router):
 
 @mark.asyncio
 async def test_hbavss_light_share_fault(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     # Injects one invalid share
     class BadDealer(HbAvssLight):
         def _get_dealer_msg(self, value):
@@ -113,10 +101,10 @@ async def test_hbavss_light_share_fault(test_router):
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
         for task in avss_tasks:
@@ -129,13 +117,6 @@ async def test_hbavss_light_share_fault(test_router):
 
 @mark.asyncio
 async def test_hbavss_light_encryption_fault(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     # Injects one undecryptable ciphertext
     class BadDealer(HbAvssLight):
         def _get_dealer_msg(self, value):
@@ -179,10 +160,10 @@ async def test_hbavss_light_encryption_fault(test_router):
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=value))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
         for task in avss_tasks:
@@ -195,12 +176,6 @@ async def test_hbavss_light_encryption_fault(test_router):
 
 @mark.asyncio
 async def test_hbavss_light_batch(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
     t = 2
     n = 3*t + 1
     batchsize = 50
@@ -223,7 +198,7 @@ async def test_hbavss_light_batch(test_router):
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=values))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
         # shares = await asyncio.gather(*avss_tasks)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
@@ -240,13 +215,6 @@ async def test_hbavss_light_batch(test_router):
 
 @mark.asyncio
 async def test_hbavss_light_batch_share_fault(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     class BadDealer(HbAvssLight):
         def _get_dealer_msg(self, value):
             if type(value) in (list, tuple):
@@ -302,7 +270,7 @@ async def test_hbavss_light_batch_share_fault(test_router):
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, value=values))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
         # shares = await asyncio.gather(*avss_tasks)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
@@ -319,13 +287,6 @@ async def test_hbavss_light_batch_share_fault(test_router):
 
 @mark.asyncio
 async def test_hbavss_batch(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     t = 2
     n = 3*t + 1
 
@@ -348,7 +309,7 @@ async def test_hbavss_batch(test_router):
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
         shares = [output[2] for output in outputs]
@@ -366,13 +327,6 @@ async def test_hbavss_batch(test_router):
 
 @mark.asyncio
 async def test_hbavss_batch_share_fault(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     # Injects one invalid share
     class BadDealer(HbAvssBatch):
         def _get_dealer_msg(self, values, n):
@@ -426,7 +380,7 @@ async def test_hbavss_batch_share_fault(test_router):
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
         shares = [output[2] for output in outputs]
@@ -444,13 +398,6 @@ async def test_hbavss_batch_share_fault(test_router):
 @mark.asyncio
 # Send t parties entirely faulty messages
 async def test_hbavss_batch_t_share_faults(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     class BadDealer(HbAvssBatch):
         def _get_dealer_msg(self, values, n):
             # return super(BadDealer, self)._get_dealer_msg(values)
@@ -506,7 +453,7 @@ async def test_hbavss_batch_t_share_faults(test_router):
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
         outputs = await asyncio.gather(
@@ -526,13 +473,6 @@ async def test_hbavss_batch_t_share_faults(test_router):
 
 @mark.asyncio
 async def test_hbavss_batch_encryption_fault(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     class BadDealer(HbAvssBatch):
         def _get_dealer_msg(self, values, n):
             fault_n = randint(1, n-1)
@@ -582,10 +522,10 @@ async def test_hbavss_batch_encryption_fault(test_router):
             stack.enter_context(hbavss)
             if i == dealer_id:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-                avss_tasks[i].add_done_callback(callback)
+                avss_tasks[i].add_done_callback(print_exception_callback)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
         shares = [output[2] for output in outputs]
@@ -720,12 +660,6 @@ async def test_hbavss_light_share_open(test_router):
 
 @mark.asyncio
 async def test_hbavss_light_parallel_share_array_open(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
     t = 2
     n = 3*t + 1
     k = 4
@@ -751,7 +685,7 @@ async def test_hbavss_light_parallel_share_array_open(test_router):
                 v, d = None, dealer_id
 
             avss_tasks[i] = asyncio.create_task(hbavss.avss_parallel(0, k, v, d))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
 
         outputs = [None]*k
         for j in range(k):
@@ -789,13 +723,6 @@ async def test_hbavss_light_parallel_share_array_open(test_router):
 
 @mark.asyncio
 async def test_hbavss_batch_batch(test_router):
-    def callback(future):
-        if future.done():
-            ex = future.exception()
-            if ex is not None:
-                print('\nException:', ex)
-                raise ex
-
     t = 2
     n = 3*t + 1
 
@@ -818,7 +745,7 @@ async def test_hbavss_batch_batch(test_router):
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, values=values))
             else:
                 avss_tasks[i] = asyncio.create_task(hbavss.avss(0, dealer_id=dealer_id))
-            avss_tasks[i].add_done_callback(callback)
+            avss_tasks[i].add_done_callback(print_exception_callback)
         outputs = await asyncio.gather(
             *[hbavss_list[i].output_queue.get() for i in range(n)])
         shares = [output[2] for output in outputs]


### PR DESCRIPTION
This PR creates an end-to-end driver for the Asynchromix app. It is based around the idea of using a Solidity smart contract as a coordinator. 

At a high level the coordinator is responsible for:
Coordinator:
1. Keeps track of offline preprocessed values. 
    - bits/triples/powers for the mixing epoch
    - input masks for client inputs
    - requires all `n` servers to report on how many preprocess values are available, taking the `min` of these
2. Accept client inputs
      - Reserves an input mask for each client
      - Accept the published "masked input" from each client
3. Initiate mixing epochs

The Asynchromix Client does:
1. Wait until an input mask is available
2. Reserve an input mask `contract.reserve_inputmask()`
3. Request shares of the input mask from the servers and reconstructs
4. Publish the masked input `contract.submit_message()`

The Asynchromix Server does:
1. Offline phase  (1a Bits/triples, 1b input masks)
  I. Wait until more input masks or more mix preprocessing is needed (try to maintain a buffer of at least 2 mixes worth)
  II. Run the offline phase (`randousha`, plus an MPC program for `generate_triples` or `generate_bits`)
  III. Submit an updated preprocessing report `contract.preprocess_report()`
2. Handling client input. If a client requests an input mask share, check that the client has already reserved the corresponding input mask `contract.client_authorized()`
3. Participating in sequential mixing `epoch`s
   a. Wait for the next mix to be initiated `contract.epochs_initiated()`
   b. Client inputs `inputs[K*epoch:K*(epoch+1)]`
   c. Preprocessing `triples[PER_MIX_TRIPLES*epoch:PER_MIX_TRIPLES*(epoch+1)]`
   d. Call the Mpc program in a fake context

Some of the challenges that had to be addressed:
- Running multiple Mpc contexts sequentially, we need to be able to specify where the preprocessing comes from. Currently we have a workaround, but the current approach is not sustainable. The workaround is to clear the `del MixinBase.pp_elements[key]` where `key` contains one server's id and then overwrite the file. A more sustainable solution would be to make the source of preprocessing a parameter to the `Mpc` context object itself. This way concurrent instances of Mpc could use different preprocessing values.
