### PR TITLE
Refactor preprocessing

### DIFF
--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -10,8 +10,7 @@ if [ "${BUILD}" == "tests" ]; then
         --cov-report=term-missing \
         --cov-report=xml \
         -Wignore::DeprecationWarning \
-        -nauto \
-        --dist=loadfile
+        -nauto 
 
     IMAGE_NAME=$(docker ps -alq --format "{{.Names}}")
     docker cp $IMAGE_NAME:/usr/src/HoneyBadgerMPC/coverage.xml .

--- a/apps/asynchromix/butterfly_network.py
+++ b/apps/asynchromix/butterfly_network.py
@@ -6,8 +6,7 @@ from time import time
 
 
 async def batch_switch(ctx, xs, ys, n):
-    pp_elements = PreProcessedElements()
-    sbits = [pp_elements.get_one_minus_one(ctx).v for _ in range(n//2)]
+    sbits = [ctx.preproc.get_one_minus_one(ctx).v for _ in range(n//2)]
     ns = [1 / ctx.field(2) for _ in range(n//2)]
 
     assert len(xs) == len(ys) == len(sbits) == n // 2
@@ -54,8 +53,11 @@ async def iterated_butterfly_network(ctx, inputs, k):
 
 async def butterfly_network_helper(ctx, **kwargs):
     k = kwargs['k']
-    pp_elements = PreProcessedElements()
-    inputs = [pp_elements.get_rand(ctx).v for _ in range(k)]
+
+    inputs = kwargs['inputs']
+    if inputs is None:
+        inputs = [ctx.preproc.get_rand(ctx).v for _ in range(k)]
+
     logging.info(f"[{ctx.myid}] Running permutation network.")
     shuffled = await iterated_butterfly_network(ctx, inputs, k)
     if shuffled is not None:

--- a/apps/asynchromix/butterfly_network.py
+++ b/apps/asynchromix/butterfly_network.py
@@ -1,14 +1,13 @@
 import asyncio
 import logging
 from math import log
-from honeybadgermpc.preprocessing import (
-    PreProcessedElements, wait_for_preprocessing, preprocessing_done)
+from honeybadgermpc.preprocessing import PreProcessedElements
 from time import time
 
 
 async def batch_switch(ctx, xs, ys, n):
     pp_elements = PreProcessedElements()
-    sbits = [pp_elements.get_one_minus_one_rand(ctx).v for _ in range(n//2)]
+    sbits = [pp_elements.get_one_minus_one(ctx).v for _ in range(n//2)]
     ns = [1 / ctx.field(2) for _ in range(n//2)]
 
     assert len(xs) == len(ys) == len(sbits) == n // 2
@@ -82,6 +81,9 @@ if __name__ == "__main__":
 
     k = int(HbmpcConfig.extras["k"])
 
+    pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
+
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
@@ -89,17 +91,17 @@ if __name__ == "__main__":
         if not HbmpcConfig.skip_preprocessing:
             if HbmpcConfig.my_id == 0:
                 NUM_SWITCHES = k * int(log(k, 2)) ** 2
-                pp_elements = PreProcessedElements()
                 pp_elements.generate_one_minus_one_rands(
                     NUM_SWITCHES, HbmpcConfig.N, HbmpcConfig.t)
                 pp_elements.generate_triples(
                     2 * NUM_SWITCHES, HbmpcConfig.N, HbmpcConfig.t)
                 pp_elements.generate_rands(k, HbmpcConfig.N, HbmpcConfig.t)
-                preprocessing_done()
+                pp_elements.preprocessing_done()
             else:
-                loop.run_until_complete(wait_for_preprocessing())
+                loop.run_until_complete(pp_elements.wait_for_preprocessing())
 
         loop.run_until_complete(
             _run(HbmpcConfig.peers, HbmpcConfig.N, HbmpcConfig.t, HbmpcConfig.my_id))
     finally:
         loop.close()
+        pp_elements.clear_preprocessing()

--- a/apps/asynchromix/powermixing.py
+++ b/apps/asynchromix/powermixing.py
@@ -4,8 +4,7 @@ from time import time
 from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.field import GF
 from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.preprocessing import PreProcessedElements, PreProcessingConstants
-from honeybadgermpc.preprocessing import wait_for_preprocessing, preprocessing_done
+from honeybadgermpc.preprocessing import PreProcessedElements
 import logging
 
 
@@ -34,7 +33,7 @@ async def all_secrets_phase1(context, **kwargs):
     stime = time()
     for i in range(k):
         file_name = f"{file_prefixes[i]}-{context.myid}.input"
-        file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{file_name}"
+        file_path = f"{pp_elements.data_directory}{file_name}"
         with open(file_path, "w") as f:
             print(context.field.modulus, file=f)
             print(as_[i].v.value, file=f)
@@ -48,9 +47,9 @@ async def all_secrets_phase1(context, **kwargs):
 
 async def phase2(node_id, run_id, file_prefix):
     input_file_name = f"{file_prefix}-{node_id}.input"
-    input_file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{input_file_name}"
+    input_file_path = f"{PreProcessedElements.DEFAULT_DIRECTORY}{input_file_name}"
     sum_file_name = f"power-{run_id}_{node_id}.sums"
-    sum_file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{sum_file_name}"
+    sum_file_path = f"{PreProcessedElements.DEFAULT_DIRECTORY}{sum_file_name}"
 
     # NOTE The binary `compute-power-sums` is generated via the command
     # make -C apps/shuffle/cpp
@@ -76,7 +75,7 @@ async def run_command_sync(command):
 async def phase3(context, **kwargs):
     k, run_id = kwargs['k'], kwargs['run_id']
     sum_file_name = f"power-{run_id}_{context.myid}.sums"
-    sum_file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{sum_file_name}"
+    sum_file_path = f"{PreProcessedElements.DEFAULT_DIRECTORY}{sum_file_name}"
     sum_shares = []
 
     bench_logger = logging.LoggerAdapter(
@@ -166,8 +165,13 @@ async def async_mixing_in_processes(network_info, n, t, k, run_id, node_id):
 if __name__ == "__main__":
     from honeybadgermpc.config import HbmpcConfig
 
+    HbmpcConfig.load_config()
+
     run_id = HbmpcConfig.extras["run_id"]
     k = int(HbmpcConfig.extras["k"])
+
+    pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
 
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
@@ -178,13 +182,12 @@ if __name__ == "__main__":
             field = GF(Subgroup.BLS12_381)
             a_s = [field(i) for i in range(1000+k, 1000, -1)]
 
-            pp_elements = PreProcessedElements()
             if HbmpcConfig.my_id == 0:
                 pp_elements.generate_rands(k, HbmpcConfig.N, HbmpcConfig.t)
                 pp_elements.generate_powers(k, HbmpcConfig.N, HbmpcConfig.t, k)
-                preprocessing_done()
+                pp_elements.preprocessing_done()
             else:
-                loop.run_until_complete(wait_for_preprocessing())
+                loop.run_until_complete(pp_elements.wait_for_preprocessing())
 
         loop.run_until_complete(
             async_mixing_in_processes(

--- a/apps/asynchromix/powermixing.py
+++ b/apps/asynchromix/powermixing.py
@@ -12,12 +12,10 @@ async def all_secrets_phase1(context, **kwargs):
     k, file_prefixes = kwargs['k'], kwargs['file_prefixes']
     as_, a_minus_b_shares, all_powers = [], [], []
 
-    pp_elements = PreProcessedElements()
-
     stime = time()
     for i in range(k):
-        a = pp_elements.get_rand(context)
-        powers = pp_elements.get_powers(context, i)
+        a = context.preproc.get_rand(context)
+        powers = context.preproc.get_powers(context, i)
         a_minus_b_shares.append(a - powers[0])
         as_.append(a)
         all_powers.append(powers)
@@ -33,7 +31,7 @@ async def all_secrets_phase1(context, **kwargs):
     stime = time()
     for i in range(k):
         file_name = f"{file_prefixes[i]}-{context.myid}.input"
-        file_path = f"{pp_elements.data_directory}{file_name}"
+        file_path = f"{context.preproc.data_directory}{file_name}"
         with open(file_path, "w") as f:
             print(context.field.modulus, file=f)
             print(as_[i].v.value, file=f)
@@ -75,7 +73,7 @@ async def run_command_sync(command):
 async def phase3(context, **kwargs):
     k, run_id = kwargs['k'], kwargs['run_id']
     sum_file_name = f"power-{run_id}_{context.myid}.sums"
-    sum_file_path = f"{PreProcessedElements.DEFAULT_DIRECTORY}{sum_file_name}"
+    sum_file_path = f"{context.preproc.data_directory}{sum_file_name}"
     sum_shares = []
 
     bench_logger = logging.LoggerAdapter(

--- a/apps/tutorial/hbmpc-tutorial-1.py
+++ b/apps/tutorial/hbmpc-tutorial-1.py
@@ -3,8 +3,7 @@ hbMPC tutorial 1. Running sample MPC programs in the testing simulator
 """
 import asyncio
 from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.progs.mixins.dataflow import (
-    Share, ShareArray, ShareFuture, GFElementFuture)
+from honeybadgermpc.progs.mixins.dataflow import Share
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements)
 from honeybadgermpc.utils.typecheck import TypeCheck
@@ -74,7 +73,6 @@ def dot_product(ctx, x_shares, y_shares):
 
 async def prog(ctx):
     # Test with random sharings of hardcoded values
-    ctx.preproc = FakePreProcessedElements()
     x = ctx.Share(5) + ctx.preproc.get_zero(ctx)
     y = ctx.Share(7) + ctx.preproc.get_zero(ctx)
     xy = await beaver_multiply(ctx, x, y)

--- a/apps/tutorial/hbmpc-tutorial-2.py
+++ b/apps/tutorial/hbmpc-tutorial-2.py
@@ -1,4 +1,4 @@
-""" 
+"""
 hbMPC tutorial 2.
 
 Instructions:
@@ -10,11 +10,7 @@ scripts/launch-tmuxlocal.sh apps/tutorial/hbmpc-tutorial-2.py conf/mpc/local
 import asyncio
 import logging
 from honeybadgermpc.preprocessing import (
-    PreProcessedElements as FakePreProcessedElements,
-    wait_for_preprocessing, preprocessing_done)
-from honeybadgermpc.progs.mixins.dataflow import (
-    Share, ShareArray, ShareFuture, GFElementFuture)
-from honeybadgermpc.utils.typecheck import TypeCheck
+    PreProcessedElements as FakePreProcessedElements)
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     MixinConstants, BeaverMultiply, BeaverMultiplyArrays)
 mpc_config = {MixinConstants.MultiplyShareArray: BeaverMultiplyArrays(),
@@ -24,14 +20,14 @@ mpc_config = {MixinConstants.MultiplyShareArray: BeaverMultiplyArrays(),
 async def dot_product(ctx, xs, ys):
     return sum((x * y for x, y in zip(xs, ys)), ctx.Share(0))
 
+
 async def prog(ctx, k=50):
     # Computing a dot product by MPC (k openings)
-    ctx.preproc = FakePreProcessedElements()
     xs = [ctx.preproc.get_bit(ctx) for _ in range(k)]
     ys = [ctx.preproc.get_bit(ctx) for _ in range(k)]
     logging.info(f"[{ctx.myid}] Running prog 1.")
     res = await dot_product(ctx, xs, ys)
-    
+
     R = await res.open()
     XS = await ctx.ShareArray(xs).open()
     YS = await ctx.ShareArray(ys).open()
@@ -50,9 +46,10 @@ async def _run(peers, n, t, my_id):
 if __name__ == "__main__":
     from honeybadgermpc.config import HbmpcConfig
     import sys
-    import os
     if not HbmpcConfig.peers:
-        print(f'WARNING: the $CONFIG_PATH environment variable wasn\'t set. Please run this file with `scripts/launch-tmuxlocal.sh apps/tutorial/hbmpc-tutorial-2.py conf/mpc/local`')
+        print(f'WARNING: the $CONFIG_PATH environment variable wasn\'t set. '
+              f'Please run this file with `scripts/launch-tmuxlocal.sh '
+              f'apps/tutorial/hbmpc-tutorial-2.py conf/mpc/local`')
         sys.exit(1)
 
     asyncio.set_event_loop(asyncio.new_event_loop())
@@ -64,9 +61,9 @@ if __name__ == "__main__":
             pp_elements = FakePreProcessedElements()
             pp_elements.generate_bits(k, HbmpcConfig.N, HbmpcConfig.t)
             pp_elements.generate_triples(k, HbmpcConfig.N, HbmpcConfig.t)
-            preprocessing_done()
+            pp_elements.preprocessing_done()
         else:
-            loop.run_until_complete(wait_for_preprocessing())
+            loop.run_until_complete(pp_elements.wait_for_preprocessing())
 
         loop.run_until_complete(
             _run(HbmpcConfig.peers, HbmpcConfig.N, HbmpcConfig.t, HbmpcConfig.my_id))

--- a/benchmark/test_benchmark_batch_opening.py
+++ b/benchmark/test_benchmark_batch_opening.py
@@ -1,15 +1,18 @@
 from pytest import mark
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 @mark.parametrize("n,t,k", [
     (4, 1, 2**i) for i in range(3, 11)]
     + [(7, 2, 2**i) for i in range(3, 11)]
 )
-def test_benchmark_batch_opening(benchmark_runner, test_preprocessing, n, t, k):
+def test_benchmark_batch_opening(benchmark_runner, n, t, k):
+    pp_elements = PreProcessedElements()
+
     num_rands = sum([2**i for i in range(3, 11)])*n
 
     async def _prog(context):
         await context.ShareArray(
-            [test_preprocessing.elements.get_rand(context) for _ in range(k)]).open()
+            [pp_elements.get_rand(context) for _ in range(k)]).open()
 
     benchmark_runner(_prog, n, t, ['rands'], num_rands)

--- a/benchmark/test_benchmark_batch_opening.py
+++ b/benchmark/test_benchmark_batch_opening.py
@@ -1,5 +1,4 @@
 from pytest import mark
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 @mark.parametrize("n,t,k", [
@@ -7,12 +6,10 @@ from honeybadgermpc.preprocessing import PreProcessedElements
     + [(7, 2, 2**i) for i in range(3, 11)]
 )
 def test_benchmark_batch_opening(benchmark_runner, n, t, k):
-    pp_elements = PreProcessedElements()
-
     num_rands = sum([2**i for i in range(3, 11)])*n
 
     async def _prog(context):
         await context.ShareArray(
-            [pp_elements.get_rand(context) for _ in range(k)]).open()
+            [context.preproc.get_rand(context) for _ in range(k)]).open()
 
     benchmark_runner(_prog, n, t, ['rands'], num_rands)

--- a/benchmark/test_benchmark_jubjub.py
+++ b/benchmark/test_benchmark_jubjub.py
@@ -3,7 +3,6 @@ from honeybadgermpc.progs.jubjub import SharedPoint, share_mul
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays, Equality)
-from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.elliptic_curve import Jubjub, Point
 
 
@@ -80,11 +79,10 @@ def test_benchmark_shared_point_montgomery_mul(
 
 @mark.parametrize("bit_length", list(range(64, 257, 64)))
 def test_benchmark_share_mul(bit_length, benchmark_runner):
-    pp_elements = PreProcessedElements()
     p = TEST_POINT
 
     async def _prog(context):
-        m_bits = [pp_elements.get_bit(context)
+        m_bits = [context.preproc.get_bit(context)
                   for i in range(bit_length)]
 
         multiplier_ = Jubjub.Field(0)

--- a/benchmark/test_benchmark_jubjub.py
+++ b/benchmark/test_benchmark_jubjub.py
@@ -3,6 +3,7 @@ from honeybadgermpc.progs.jubjub import SharedPoint, share_mul
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays, Equality)
+from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.elliptic_curve import Jubjub, Point
 
 
@@ -78,11 +79,12 @@ def test_benchmark_shared_point_montgomery_mul(
 
 
 @mark.parametrize("bit_length", list(range(64, 257, 64)))
-def test_benchmark_share_mul(bit_length, test_preprocessing, benchmark_runner):
+def test_benchmark_share_mul(bit_length, benchmark_runner):
+    pp_elements = PreProcessedElements()
     p = TEST_POINT
 
     async def _prog(context):
-        m_bits = [test_preprocessing.elements.get_bit(context)
+        m_bits = [pp_elements.get_bit(context)
                   for i in range(bit_length)]
 
         multiplier_ = Jubjub.Field(0)

--- a/benchmark/test_benchmark_mimc.py
+++ b/benchmark/test_benchmark_mimc.py
@@ -5,7 +5,6 @@ from honeybadgermpc.progs.mimc import mimc_mpc_batch
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays, Equality)
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 CONFIG = {
     BeaverMultiply.name: BeaverMultiply(),
@@ -29,10 +28,8 @@ TEST_KEY = TEST_FIELD(randint(0, TEST_FIELD.modulus))
 # All iterations take around 30min total.
 @mark.parametrize("batch_size", [10**i for i in range(4)])
 def test_benchmark_mimc_mpc_batch(batch_size, benchmark_runner):
-    pp_elements = PreProcessedElements()
-
     async def _prog(context):
-        xs = [pp_elements.get_rand(context)
+        xs = [context.preproc.get_rand(context)
               for _ in range(batch_size)]
         await mimc_mpc_batch(context, xs, TEST_KEY)
 

--- a/benchmark/test_benchmark_mimc.py
+++ b/benchmark/test_benchmark_mimc.py
@@ -5,6 +5,7 @@ from honeybadgermpc.progs.mimc import mimc_mpc_batch
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays, Equality)
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 CONFIG = {
     BeaverMultiply.name: BeaverMultiply(),
@@ -27,9 +28,12 @@ TEST_KEY = TEST_FIELD(randint(0, TEST_FIELD.modulus))
 
 # All iterations take around 30min total.
 @mark.parametrize("batch_size", [10**i for i in range(4)])
-def test_benchmark_mimc_mpc_batch(batch_size, test_preprocessing, benchmark_runner):
+def test_benchmark_mimc_mpc_batch(batch_size, benchmark_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
-        xs = [test_preprocessing.elements.get_rand(context) for _ in range(batch_size)]
+        xs = [pp_elements.get_rand(context)
+              for _ in range(batch_size)]
         await mimc_mpc_batch(context, xs, TEST_KEY)
 
     benchmark_runner(_prog, n, t, PREPROCESSING, k)

--- a/benchmark/test_benchmark_preprocessing.py
+++ b/benchmark/test_benchmark_preprocessing.py
@@ -9,6 +9,7 @@ from honeybadgermpc.preprocessing import PreProcessedElements
 ])
 def test_benchmark_generate_rands(benchmark, n, t, k):
     pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
     benchmark(pp_elements.generate_rands, k, n, t)
 
 
@@ -19,4 +20,5 @@ def test_benchmark_generate_rands(benchmark, n, t, k):
 ])
 def test_benchmark_generate_powers(benchmark, n, t, k, z):
     pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
     benchmark(pp_elements.generate_powers, k, n, t, z)

--- a/honeybadgermpc/mpc.py
+++ b/honeybadgermpc/mpc.py
@@ -307,7 +307,7 @@ async def test_prog1(context):
     y = pp_elements.get_zero(context) + context.Share(15)
     # y = context.Share(15)
 
-    a, b, ab = pp_elements.get_triple(context)
+    a, b, ab = pp_elements.get_triples(context)
     # assert await a.open() * await b.open() == await ab.open()
 
     d = (x - a).open()

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -496,7 +496,7 @@ class PreProcessedElements:
             data_directory=None,
             field=None):
         """ Called when a new PreProcessedElements is created.
-        This creates a multiton based on the field used in preprocessing
+        This creates a multiton based on the directory used in preprocessing
         """
         if data_directory is None:
             data_directory = cls.DEFAULT_DIRECTORY

--- a/honeybadgermpc/progs/jubjub.py
+++ b/honeybadgermpc/progs/jubjub.py
@@ -51,9 +51,6 @@ class SharedPoint(object):
 
         return res
 
-        # x, y = await asyncio.gather(self.xs.open(), self.ys.open())
-        # return Point(x, y, self.curve)
-
     def equals(self, other):
         """Returns a future that evaluates to the result of the equality check
         """

--- a/honeybadgermpc/progs/mimc.py
+++ b/honeybadgermpc/progs/mimc.py
@@ -1,5 +1,6 @@
 from math import log, ceil
-from honeybadgermpc.mpc import PreProcessedElements, Subgroup
+from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.mpc import PreProcessedElements
 
 # ROUND: iteration time of MiMC encryption function,
 # In BLS12_381, r = ceil(log(p, 3)) = 161
@@ -24,7 +25,7 @@ async def mimc_mpc(context, x, k):
 
     # def cubing_share(): [x] -> [x^3]
     async def cubing_share(x):
-        r1, r2, r3 = pp_elements.get_cube(context)
+        r1, r2, r3 = pp_elements.get_cubes(context)
         y = await (x - r1).open()
         # [x^3] = 3y[r^2] + 3y^2[r] + y^3 + [r^3]
         x3 = 3*y*r2 + 3*(y**2)*r1 + y**3 + r3
@@ -33,7 +34,7 @@ async def mimc_mpc(context, x, k):
     # iterating the round function ROUND times
     inp = x
     for ctr in range(ROUND):
-        inp = await cubing_share((k + context.field(ctr)) + inp)
+        inp = await cubing_share(k + (context.field(ctr) + inp))
 
     return inp + k
 
@@ -47,22 +48,12 @@ async def mimc_mpc_batch(context, xs, k):
 
     # def cubing_share_array(): [x1,..., xK] -> [x1^3,..., xK^3]
     async def cubing_share_array(xs):
-        rs, rs_sq, rs_cube = [], [], []
-        x3s = []
-
-        for x in xs:
-            r1, r2, r3 = pp_elements.get_cube(context)
-            y = await (x - r1).open()
-            rs.append(r1)
-            rs_sq.append(r2)
-            rs_cube.append(r3)
+        rs, rs_sq, rs_cube = zip(*[pp_elements.get_cubes(context)
+                                   for _ in range(len(xs))])
 
         ys = await (context.ShareArray(xs) - context.ShareArray(rs)).open()
-        for i, y in enumerate(ys):
-            # [x^3] = 3y[r^2] + 3y^2[r] + y^3 + [r^3]
-            x3s.append(3*y*rs_sq[i] + 3*(y**2)*rs[i] + y**3 + rs_cube[i])
-
-        return x3s
+        return [3*y*rs_sq[i] + 3*(y**2)*rs[i] + y**3 + rs_cube[i]
+                for i, y in enumerate(ys)]
 
     # iterating the round function ROUND times
     inp_array = xs

--- a/honeybadgermpc/progs/mimc.py
+++ b/honeybadgermpc/progs/mimc.py
@@ -1,6 +1,5 @@
 from math import log, ceil
 from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.mpc import PreProcessedElements
 
 # ROUND: iteration time of MiMC encryption function,
 # In BLS12_381, r = ceil(log(p, 3)) = 161
@@ -21,11 +20,9 @@ async def mimc_mpc(context, x, k):
     where either x or k can be secret share, the other is an element of F_p
     See: https://eprint.iacr.org/2016/542.pdf
     """
-    pp_elements = PreProcessedElements()
-
     # def cubing_share(): [x] -> [x^3]
     async def cubing_share(x):
-        r1, r2, r3 = pp_elements.get_cubes(context)
+        r1, r2, r3 = context.preproc.get_cubes(context)
         y = await (x - r1).open()
         # [x^3] = 3y[r^2] + 3y^2[r] + y^3 + [r^3]
         x3 = 3*y*r2 + 3*(y**2)*r1 + y**3 + r3
@@ -44,11 +41,9 @@ async def mimc_mpc_batch(context, xs, k):
     MiMC block cipher encryption encrypts blocks of message xs with secret key k,
     where xs are a list of shared secrets, k is an element of F_p
     """
-    pp_elements = PreProcessedElements()
-
     # def cubing_share_array(): [x1,..., xK] -> [x1^3,..., xK^3]
     async def cubing_share_array(xs):
-        rs, rs_sq, rs_cube = zip(*[pp_elements.get_cubes(context)
+        rs, rs_sq, rs_cube = zip(*[context.preproc.get_cubes(context)
                                    for _ in range(len(xs))])
 
         ys = await (context.ShareArray(xs) - context.ShareArray(rs)).open()

--- a/honeybadgermpc/progs/mimc_jubjub_pkc.py
+++ b/honeybadgermpc/progs/mimc_jubjub_pkc.py
@@ -1,5 +1,4 @@
 import asyncio
-from honeybadgermpc.mpc import PreProcessedElements
 from honeybadgermpc.elliptic_curve import Point, Jubjub
 from honeybadgermpc.progs.jubjub import share_mul
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
@@ -16,10 +15,8 @@ async def key_generation(context, key_length=32):
     as the private key (priv_key),
     then calcultes X = ([x]G).open as the public key (pub_key)
     """
-    pp_elements = PreProcessedElements()
-
     # Generate the private key
-    priv_key = [pp_elements.get_bit(context) for _ in range(key_length)]
+    priv_key = [context.preproc.get_bit(context) for _ in range(key_length)]
 
     # Compute [X] = [x]G, then open it as public key
     pub_key_share = await share_mul(context, priv_key, GP)

--- a/honeybadgermpc/progs/mimc_jubjub_pkc.py
+++ b/honeybadgermpc/progs/mimc_jubjub_pkc.py
@@ -1,5 +1,4 @@
 import asyncio
-from random import randint
 from honeybadgermpc.mpc import PreProcessedElements
 from honeybadgermpc.elliptic_curve import Point, Jubjub
 from honeybadgermpc.progs.jubjub import share_mul
@@ -43,7 +42,7 @@ def mimc_encrypt(pub_key, ms, seed=None):
     """
 
     # Randomly generated variable hold only by the dealer
-    a = randint(0, Jubjub.Field.modulus) if seed is None else seed
+    a = Jubjub.Field.random() if seed is None else seed
     # Auxiliary variable needed for decryption
     a_ = a * GP
 
@@ -74,6 +73,7 @@ async def mimc_decrypt(context, priv_key, ciphertext):
 
     mpcs = await asyncio.gather(*[mimc_mpc(context, context.field(i), k_share)
                                   for i in range(len(cs))])
+
     decrypted = [c - m for (c, m) in zip(cs, mpcs)]
 
     return decrypted

--- a/honeybadgermpc/progs/mimc_symmetric.py
+++ b/honeybadgermpc/progs/mimc_symmetric.py
@@ -1,9 +1,8 @@
 import asyncio
 from honeybadgermpc.field import GF
-from honeybadgermpc.mpc import PreProcessedElements, Subgroup
+from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
 
-pp_elements = PreProcessedElements()
 field = GF(Subgroup.BLS12_381)
 
 
@@ -21,7 +20,7 @@ async def mimc_decrypt(context, key, cs):
     plaintext <- F_MiMC(counter, key) - ciphertext
     """
     mpcs = await asyncio.gather(*[mimc_mpc(context, context.field(i), key)
-                                for i in range(len(cs))])
+                                  for i in range(len(cs))])
     decrypted = [c - m for (c, m) in zip(cs, mpcs)]
 
     return decrypted

--- a/honeybadgermpc/progs/mixins/base.py
+++ b/honeybadgermpc/progs/mixins/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.utils.typecheck import TypeCheck
 
 
@@ -7,8 +6,6 @@ class MixinBase(ABC):
     """Abstract base class for all Mixin objects
     These will work like drag-and-drop functors to load in some mpc applications
     """
-    pp_elements = PreProcessedElements()
-
     @abstractmethod
     def __call__(self, *args, **kwargs):
         """Subclasses of MixinBase most override this method, as this is

--- a/honeybadgermpc/progs/mixins/share_arithmetic.py
+++ b/honeybadgermpc/progs/mixins/share_arithmetic.py
@@ -1,4 +1,4 @@
-from honeybadgermpc.progs.mixins.base import MixinBase, AsyncMixin
+from honeybadgermpc.progs.mixins.base import AsyncMixin
 from honeybadgermpc.progs.mixins.constants import MixinConstants
 from honeybadgermpc.utils.typecheck import TypeCheck
 from honeybadgermpc.progs.mixins.dataflow import Share, ShareArray
@@ -15,7 +15,7 @@ class BeaverMultiply(AsyncMixin):
     @staticmethod
     @TypeCheck()
     async def _prog(context: Mpc, x: Share, y: Share):
-        a, b, ab = MixinBase.pp_elements.get_triples(context)
+        a, b, ab = context.preproc.get_triples(context)
 
         d, e = await gather(*[(x - a).open(), (y - b).open()])
         xy = d*e + d*b + e*a + ab
@@ -34,7 +34,7 @@ class BeaverMultiplyArrays(AsyncMixin):
 
         a, b, ab = [], [], []
         for _ in range(len(j)):
-            p, q, pq = MixinBase.pp_elements.get_triples(context)
+            p, q, pq = context.preproc.get_triples(context)
             a.append(p)
             b.append(q)
             ab.append(pq)
@@ -56,7 +56,7 @@ class DoubleSharingMultiply(AsyncMixin):
     async def reduce_degree_share(context: Mpc, x_2t: Share):
         assert x_2t.t == context.t*2
 
-        r_t, r_2t = MixinBase.pp_elements.get_double_shares(context)
+        r_t, r_2t = context.preproc.get_double_shares(context)
         diff = await (x_2t - r_2t).open()
 
         return r_t + diff
@@ -81,7 +81,7 @@ class DoubleSharingMultiplyArrays(AsyncMixin):
 
         r_t, r_2t = [], []
         for _ in range(len(x_2t)):
-            r_t_, r_2t_ = MixinBase.pp_elements.get_double_shares(context)
+            r_t_, r_2t_ = context.preproc.get_double_shares(context)
             r_t.append(r_t_)
             r_2t.append(r_2t_)
 
@@ -110,7 +110,7 @@ class InvertShare(AsyncMixin):
     @staticmethod
     @TypeCheck()
     async def _prog(context: Mpc, x: Share):
-        r = MixinBase.pp_elements.get_rand(context)
+        r = context.preproc.get_rand(context)
         sig = await (x*r).open()
 
         return r * (1/sig)
@@ -124,7 +124,7 @@ class InvertShareArray(AsyncMixin):
     @staticmethod
     @TypeCheck()
     async def _prog(context: Mpc, xs: ShareArray):
-        rs = context.ShareArray([MixinBase.pp_elements.get_rand(context)
+        rs = context.ShareArray([context.preproc.get_rand(context)
                                  for _ in range(len(xs))])
 
         sigs = await (await (xs*rs)).open()
@@ -183,14 +183,14 @@ class Equality(AsyncMixin):
     @TypeCheck()
     async def _gen_test_bit(context: Mpc, diff: Share):
         # # b \in {0, 1}
-        b = MixinBase.pp_elements.get_bit(context)
+        b = context.preproc.get_bit(context)
 
         # # _b \in {5, 1}, for p = 1 mod 8, s.t. (5/p) = -1
         # # so _b = -4 * b + 5
         _b = (-4 * b) + context.Share(5)
 
-        _r = MixinBase.pp_elements.get_rand(context)
-        _rp = MixinBase.pp_elements.get_rand(context)
+        _r = context.preproc.get_rand(context)
+        _rp = context.preproc.get_rand(context)
 
         # c = a * r + b * rp * rp
         # If b_i == 1, c_i is guaranteed to be a square modulo p if a is zero

--- a/honeybadgermpc/progs/mixins/share_comparison.py
+++ b/honeybadgermpc/progs/mixins/share_comparison.py
@@ -30,14 +30,14 @@ class Equality(AsyncMixin):
     @TypeCheck()
     async def _gen_test_bit(context: Mpc, diff: Share):
         # # b \in {0, 1}
-        b = Equality.pp_elements.get_bit(context)
+        b = context.preproc.get_bit(context)
 
         # # _b \in {5, 1}, for p = 1 mod 8, s.t. (5/p) = -1
         # # so _b = -4 * b + 5
         _b = (-4 * b) + context.Share(5)
 
-        _r = Equality.pp_elements.get_rand(context)
-        _rp = Equality.pp_elements.get_rand(context)
+        _r = context.preproc.get_rand(context)
+        _rp = context.preproc.get_rand(context)
 
         # c = a * r + b * rp * rp
         # If b_i == 1, c_i is guaranteed to be a square modulo p if a is zero
@@ -117,7 +117,7 @@ class LessThan(AsyncMixin):
         """
         z = a_share - b_share
 
-        r_b, r_bits = LessThan.pp_elements.get_share_bits(context)
+        r_b, r_bits = context.preproc.get_share_bits(context)
 
         # [c] = 2[z] + [r]_B = 2([a]-[b]) + [r]_B
         c = await (2 * z + r_b).open()
@@ -164,7 +164,7 @@ class LessThan(AsyncMixin):
         """
         bit_length = context.field.modulus.bit_length()
 
-        s_b, s_bits = LessThan.pp_elements.get_share_bits(context)
+        s_b, s_bits = context.preproc.get_share_bits(context)
         d_ = s_b + x
         d = await d_.open()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,7 +2,9 @@ from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.router import SimpleRouter
 import asyncio
 import random
+from tempfile import mkdtemp
 from pytest import fixture
+from os import makedirs
 
 
 @fixture
@@ -79,49 +81,28 @@ def triples_polys(request, triples_fields, polynomial):
 
 
 class TestPreProcessing():
+    """ This class, when initialized, creates a temporary data directory.
+    It then creates a PreProcessedElements object using that directory,
+    and sets it as the singleton for the testing field.
+    Thus, as the fixture has autouse=True, anytime code calls PreProcessedElements(),
+    it will return this created object.
+    """
+
     def __init__(self):
         from honeybadgermpc.preprocessing import PreProcessedElements
-        self.cache = {}
-        self.elements = PreProcessedElements()
+        from honeybadgermpc.preprocessing import PreProcessingConstants as Constants
+        from honeybadgermpc.progs.mixins.base import MixinBase
 
-    def generate(self, kind, n, t, arg1=None, arg2=None, k=1000):
-        if kind in [
-            "zeros",
-            "triples",
-            "cubes",
-            "rands",
-            "bits",
-            "oneminusone",
-            "double_shares",
-            "powers",
-            "share_bits"
-        ]:
-            if (kind, n, t) in self.cache:
-                return
-            self.cache[(kind, n, t)] = True
-            if kind == "zeros":
-                self.elements.generate_zeros(k, n, t)
-            elif kind == "triples":
-                self.elements.generate_triples(k, n, t)
-            elif kind == "cubes":
-                self.elements.generate_cubes(k, n, t)
-            elif kind == "rands":
-                self.elements.generate_rands(k, n, t)
-            elif kind == "bits":
-                self.elements.generate_bits(k, n, t)
-            elif kind == "oneminusone":
-                self.elements.generate_one_minus_one_rands(k, n, t)
-            elif kind == "double_shares":
-                self.elements.generate_double_shares(k, n, t)
-            elif kind == "powers":
-                self.elements.generate_powers(arg1, n, t, arg2)
-            elif kind == "share_bits":
-                self.elements.generate_share_bits(k, n, t)
-        elif kind == "share":
-            return self.elements.generate_share(arg1, n, t)
+        makedirs(Constants.SHARED_DATA_DIR.value, exist_ok=True)
+        self.test_data_dir = f"{mkdtemp(dir=Constants.SHARED_DATA_DIR.value)}/"
+        PreProcessedElements.DEFAULT_DIRECTORY = self.test_data_dir
+
+        PreProcessedElements.reset_cache()
+        self.elements = PreProcessedElements(data_directory=self.test_data_dir)
+        MixinBase.pp_elements = self.elements
 
 
-@fixture(scope="session")
+@fixture(scope="session", autouse=True)
 def test_preprocessing():
     return TestPreProcessing()
 
@@ -172,9 +153,12 @@ def _build_config(mixins=[]):
 
 
 @fixture
-def test_runner(test_preprocessing):
+def test_runner():
+    from honeybadgermpc.preprocessing import PreProcessedElements
+
     async def _test_runner(prog, n=4, t=1, to_generate=[], k=1000, mixins=[]):
-        _preprocess(test_preprocessing, n, t, k, to_generate)
+        pp_elements = PreProcessedElements()
+        _preprocess(pp_elements, n, t, k, to_generate)
 
         config = _build_config(mixins)
         program_runner = TaskProgramRunner(n, t, config)
@@ -186,10 +170,12 @@ def test_runner(test_preprocessing):
 
 
 @fixture
-def benchmark_runner(benchmark, test_preprocessing):
-    def _benchmark_runner(prog, n=4, t=1, to_generate=[], k=1000, mixins=[]):
+def benchmark_runner(benchmark):
+    from honeybadgermpc.preprocessing import PreProcessedElements
 
-        _preprocess(test_preprocessing, n, t, k, to_generate)
+    def _benchmark_runner(prog, n=4, t=1, to_generate=[], k=1000, mixins=[]):
+        pp_elements = PreProcessedElements()
+        _preprocess(pp_elements, n, t, k, to_generate)
 
         config = _build_config(mixins)
         program_runner = TaskProgramRunner(n, t, config)

--- a/tests/progs/mixins/test_share_arithmetic.py
+++ b/tests/progs/mixins/test_share_arithmetic.py
@@ -1,6 +1,7 @@
 from pytest import mark, raises
 from asyncio import gather
 from random import randint
+from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays, DoubleSharingMultiply, DoubleSharingMultiplyArrays)
@@ -30,13 +31,14 @@ async def run_test_program(prog, test_runner, n=n, t=t, k=1000,
 
 
 @mark.asyncio
-async def test_degree_reduction_share(galois_field, test_preprocessing, test_runner):
+async def test_degree_reduction_share(galois_field, test_runner):
     n, t = 7, 2
+    pp_elements = PreProcessedElements()
     x_expected = galois_field.random().value
-    sid_x_2t = test_preprocessing.generate("share", n, 2*t, x_expected)
+    sid_x_2t = pp_elements.generate('share', n, 2*t, x_expected)
 
     async def _prog(context):
-        sh_x_2t = test_preprocessing.elements.get_share(context, sid_x_2t, 2*t)
+        sh_x_2t = pp_elements.get_share(context, sid_x_2t, 2*t)
         x_actual = await (
             await DoubleSharingMultiply.reduce_degree_share(context, sh_x_2t)).open()
         assert x_expected == x_actual
@@ -45,12 +47,15 @@ async def test_degree_reduction_share(galois_field, test_preprocessing, test_run
 
 
 @mark.asyncio
-async def test_degree_reduction_share_array(test_preprocessing, test_runner):
+async def test_degree_reduction_share_array(test_runner):
     n, t = 7, 2
-    test_preprocessing.generate("rands", n, 2*t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("rands", n, 2*t)
+    pp_elements.generate("double_shares", n, t)
 
     async def _prog(context):
-        shares = [test_preprocessing.elements.get_rand(context, 2*t) for _ in range(10)]
+        shares = [pp_elements.get_rand(
+            context, 2*t) for _ in range(10)]
         sh_x_2t = context.ShareArray(shares, 2*t)
         x_actual = await (
             await DoubleSharingMultiplyArrays.reduce_degree_share_array(
@@ -65,13 +70,13 @@ async def test_degree_reduction_share_array(test_preprocessing, test_runner):
 
 @mark.asyncio
 async def test_multiplication_using_double_sharing(galois_field,
-                                                   test_preprocessing,
                                                    test_runner):
     n, t = 9, 2
+    pp_elements = PreProcessedElements()
 
     async def _prog(context):
-        sh_a = test_preprocessing.elements.get_rand(context)
-        sh_b = test_preprocessing.elements.get_rand(context)
+        sh_a = pp_elements.get_rand(context)
+        sh_b = pp_elements.get_rand(context)
         ab_expected = await sh_a.open() * await sh_b.open()
 
         ab_actual = await(await (sh_a * sh_b)).open()
@@ -82,12 +87,12 @@ async def test_multiplication_using_double_sharing(galois_field,
 
 @mark.asyncio
 async def test_batch_double_sharing_multiply(galois_field,
-                                             test_preprocessing,
                                              test_runner):
     n, t = 9, 2
+    pp_elements = PreProcessedElements()
 
     async def _prog(context):
-        shares = [test_preprocessing.elements.get_rand(context) for _ in range(20)]
+        shares = [pp_elements.get_rand(context) for _ in range(20)]
         p = context.ShareArray(shares[:10])
         q = context.ShareArray(shares[10:])
 
@@ -101,13 +106,14 @@ async def test_batch_double_sharing_multiply(galois_field,
 
 
 @mark.asyncio
-async def test_cant_multiply_shares_from_different_contexts(test_preprocessing):
+async def test_cant_multiply_shares_from_different_contexts():
     from honeybadgermpc.mpc import TaskProgramRunner
     import asyncio
 
     n, t = 9, 2
 
-    [test_preprocessing.generate(i, n, t, k=2000) for i in ['double_shares', 'rands']]
+    pp_elements = PreProcessedElements()
+    [pp_elements.generate(i, n, t, k=2000) for i in ['double_shares', 'rands']]
 
     async def _prog(context):
         share = context.Share(1)
@@ -132,13 +138,14 @@ async def test_cant_multiply_shares_from_different_contexts(test_preprocessing):
 
 
 @mark.asyncio
-async def test_beaver_mul_with_zeros(test_preprocessing, test_runner):
+async def test_beaver_mul_with_zeros(test_runner):
+    pp_elements = PreProcessedElements()
     x_secret, y_secret = 10, 15
 
     async def _prog(context):
         # Example of Beaver multiplication
-        x = test_preprocessing.elements.get_zero(context) + context.Share(x_secret)
-        y = test_preprocessing.elements.get_zero(context) + context.Share(y_secret)
+        x = pp_elements.get_zero(context) + context.Share(x_secret)
+        y = pp_elements.get_zero(context) + context.Share(y_secret)
 
         xy = await (x*y)
 
@@ -154,11 +161,13 @@ async def test_beaver_mul_with_zeros(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_beaver_mul(test_preprocessing, test_runner):
+async def test_beaver_mul(test_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
         # Example of Beaver multiplication
-        x = test_preprocessing.elements.get_rand(context)
-        y = test_preprocessing.elements.get_rand(context)
+        x = pp_elements.get_rand(context)
+        y = pp_elements.get_rand(context)
 
         xy = await (x*y)
 
@@ -173,9 +182,11 @@ async def test_beaver_mul(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_batch_beaver_multiply(test_preprocessing, test_runner):
+async def test_batch_beaver_multiply(test_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
-        shares = [test_preprocessing.elements.get_rand(context) for _ in range(20)]
+        shares = [pp_elements.get_rand(context) for _ in range(20)]
         p = context.ShareArray(shares[:10])
         q = context.ShareArray(shares[10:])
 
@@ -189,11 +200,12 @@ async def test_batch_beaver_multiply(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_invert_share(test_preprocessing, test_runner):
+async def test_invert_share(test_runner):
+    pp_elements = PreProcessedElements()
     inverter = InvertShare()
 
     async def _prog(context):
-        share = test_preprocessing.elements.get_rand(context)
+        share = pp_elements.get_rand(context)
         # assert 1/x * x == 1
         inverted = await inverter(context, share)
         assert await (inverted * share).open() == 1
@@ -203,12 +215,13 @@ async def test_invert_share(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_invert_share_array(test_preprocessing, test_runner):
+async def test_invert_share_array(test_runner):
+    pp_elements = PreProcessedElements()
     inverter = InvertShareArray()
 
     async def _prog(context):
         shares = context.ShareArray(
-            [test_preprocessing.elements.get_rand(context) for _ in range(20)])
+            [pp_elements.get_rand(context) for _ in range(20)])
         inverted_shares = await(inverter(context, shares))
 
         product = await(shares * inverted_shares)
@@ -220,9 +233,11 @@ async def test_invert_share_array(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_share_division(test_preprocessing, test_runner):
+async def test_share_division(test_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
-        r1 = test_preprocessing.elements.get_rand(context)
+        r1 = pp_elements.get_rand(context)
         assert await(await(r1 / r1)).open() == 1
 
     results = await run_test_program(_prog, test_runner)
@@ -230,9 +245,11 @@ async def test_share_division(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_share_division_needs_mixins(test_preprocessing, test_runner):
+async def test_share_division_needs_mixins(test_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
-        r1 = test_preprocessing.elements.get_rand(context)
+        r1 = pp_elements.get_rand(context)
         with raises(NotImplementedError):
             assert await(await(r1 / r1)).open() == 1
 
@@ -241,10 +258,12 @@ async def test_share_division_needs_mixins(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_share_array_division(test_preprocessing, test_runner):
+async def test_share_array_division(test_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
         shares = context.ShareArray(
-            [test_preprocessing.elements.get_rand(context) for _ in range(20)])
+            [pp_elements.get_rand(context) for _ in range(20)])
 
         result = await(shares / shares)
         for e in await(result).open():

--- a/tests/progs/mixins/test_share_comparison.py
+++ b/tests/progs/mixins/test_share_comparison.py
@@ -1,5 +1,5 @@
-import logging
 from pytest import mark
+from asyncio import gather
 from random import randint
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
@@ -7,6 +7,7 @@ from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays)
 from honeybadgermpc.progs.mixins.share_comparison import Equality, LessThan
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 STANDARD_ARITHMETIC_MIXINS = [
     BeaverMultiply(),
@@ -20,8 +21,7 @@ STANDARD_ARITHMETIC_MIXINS = [
 ]
 
 PREPROCESSING = ['rands', 'triples', 'zeros', 'cubes', 'bits']
-n, t = 4, 1
-k = 10000
+n, t = 3, 1
 
 FIELD = GF(Subgroup.BLS12_381)
 
@@ -34,8 +34,9 @@ range_pairs = [(x, y) for x, y in zip(ranges[:-1], ranges[1:])]
 
 @mark.asyncio
 @mark.parametrize("begin,end", range_pairs)
-async def test_less_than(begin, end, test_preprocessing, test_runner):
-    test_preprocessing.generate('share_bits', n, t, k=50)
+async def test_less_than(begin, end, test_runner):
+    pp_elements = PreProcessedElements()
+    pp_elements.generate('share_bits', n, t, k=50)
     a_values = [randint(begin, end) for _ in range(3)]
     b_values = [a_values[0] - DIFF, a_values[1], a_values[2] + DIFF]
 
@@ -43,27 +44,28 @@ async def test_less_than(begin, end, test_preprocessing, test_runner):
         a_shares = [context.Share(v) for v in a_values]
         b_shares = [context.Share(v) for v in b_values]
 
-        for (a_, b_, a, b) in zip(a_shares, b_shares, a_values, b_values):
-            if context.myid == 0:
-                logging.info(f"a: {a}; b: {b}")
-            res = bool(await (a_ < b_).open())
-            assert res == (a < b)
+        results = await gather(*[(a_ < b_).open()
+                                 for a_, b_ in zip(a_shares, b_shares)])
 
-    await test_runner(_prog, n, t, PREPROCESSING, k, STANDARD_ARITHMETIC_MIXINS)
+        for (res, a, b) in zip(results, a_values, b_values):
+            assert bool(res) == (a < b)
+
+    await test_runner(_prog, n, t, PREPROCESSING, 2500, STANDARD_ARITHMETIC_MIXINS)
 
 
 @mark.asyncio
-async def test_equality(test_preprocessing, test_runner):
+async def test_equality(test_runner):
     equality = Equality()
+    pp_elements = PreProcessedElements()
 
     async def _prog(context):
-        share0 = test_preprocessing.elements.get_zero(context)
-        share1 = test_preprocessing.elements.get_rand(context)
+        share0 = pp_elements.get_zero(context)
+        share1 = pp_elements.get_rand(context)
         share1_ = share0 + share1
-        share2 = test_preprocessing.elements.get_rand(context)
+        share2 = pp_elements.get_rand(context)
 
         assert await (await equality(context, share1, share1_)).open()
         assert await (share1 == share1_).open()
         assert not await (share1 == share2).open()
 
-    await test_runner(_prog, n, t, PREPROCESSING, k, STANDARD_ARITHMETIC_MIXINS)
+    await test_runner(_prog, n, t, PREPROCESSING, 1000, STANDARD_ARITHMETIC_MIXINS)

--- a/tests/progs/mixins/test_share_comparison.py
+++ b/tests/progs/mixins/test_share_comparison.py
@@ -56,13 +56,12 @@ async def test_less_than(begin, end, test_runner):
 @mark.asyncio
 async def test_equality(test_runner):
     equality = Equality()
-    pp_elements = PreProcessedElements()
 
     async def _prog(context):
-        share0 = pp_elements.get_zero(context)
-        share1 = pp_elements.get_rand(context)
+        share0 = context.preproc.get_zero(context)
+        share1 = context.preproc.get_rand(context)
         share1_ = share0 + share1
-        share2 = pp_elements.get_rand(context)
+        share2 = context.preproc.get_rand(context)
 
         assert await (await equality(context, share1, share1_)).open()
         assert await (share1 == share1_).open()

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -7,6 +7,7 @@ from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays)
 from honeybadgermpc.progs.mixins.share_comparison import Equality
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 TEST_CURVE = Jubjub()
 
@@ -36,10 +37,10 @@ STANDARD_PREPROCESSING = [
     'rands', 'triples', 'bits'
 ]
 
-n, t = 4, 1
+n, t = 3, 1
 
 
-async def run_test_program(prog, test_runner, n=n, t=t, k=10000,
+async def run_test_program(prog, test_runner, n=n, t=t, k=1000,
                            mixins=STANDARD_ARITHMETIC_MIXINS):
 
     return await test_runner(prog, n, t, STANDARD_PREPROCESSING, k, mixins)
@@ -77,7 +78,7 @@ def test_basic_point_functionality():
 
 
 @mark.asyncio
-async def test_shared_point_equals(test_preprocessing, test_runner):
+async def test_shared_point_equals(test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[0])
         p2 = SharedPoint.from_point(context, TEST_POINTS[1])
@@ -100,7 +101,7 @@ async def test_shared_point_equals(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_creation_from_point(test_preprocessing, test_runner):
+async def test_shared_point_creation_from_point(test_runner):
     async def _prog(context):
         p1 = Point(0, 1)
         p1s = SharedPoint.from_point(context, p1)
@@ -110,7 +111,7 @@ async def test_shared_point_creation_from_point(test_preprocessing, test_runner)
 
 
 @mark.asyncio
-async def test_shared_point_double(test_preprocessing, test_runner):
+async def test_shared_point_double(test_runner):
     async def _prog(context):
         shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
         actual_doubled = [SharedPoint.from_point(
@@ -124,7 +125,7 @@ async def test_shared_point_double(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_neg(test_preprocessing, test_runner):
+async def test_shared_point_neg(test_runner):
     async def _prog(context):
         shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
         actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
@@ -138,7 +139,7 @@ async def test_shared_point_neg(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_add(test_preprocessing, test_runner):
+async def test_shared_point_add(test_runner):
     async def _prog(context):
         ideal = SharedIdeal(TEST_CURVE)
 
@@ -157,7 +158,7 @@ async def test_shared_point_add(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_sub(test_preprocessing, test_runner):
+async def test_shared_point_sub(test_runner):
     async def _prog(context):
         shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
         actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
@@ -173,7 +174,7 @@ async def test_shared_point_sub(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_mul(test_preprocessing, test_runner):
+async def test_shared_point_mul(test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[1])
         p1_double = p1.double()
@@ -189,7 +190,7 @@ async def test_shared_point_mul(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
+async def test_shared_point_montgomery_mul(test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[1])
         p1_double = p1.double()
@@ -207,14 +208,15 @@ async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_share_mul(test_preprocessing, test_runner):
-    bit_length = 80  # Short key for testing
+async def test_share_mul(test_runner):
+    bit_length = 40  # Short key for testing
+    pp_elements = PreProcessedElements()
 
     async def _prog(context):
         p = TEST_POINTS[1]
 
         multiplier_ = Jubjub.Field(0)
-        m_bits = [test_preprocessing.elements.get_bit(context)
+        m_bits = [pp_elements.get_bit(context)
                   for i in range(bit_length)]
 
         for idx, m in enumerate(m_bits):

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -7,7 +7,6 @@ from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply, BeaverMultiplyArrays, InvertShare, InvertShareArray, DivideShares,
     DivideShareArrays)
 from honeybadgermpc.progs.mixins.share_comparison import Equality
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 TEST_CURVE = Jubjub()
 
@@ -210,13 +209,12 @@ async def test_shared_point_montgomery_mul(test_runner):
 @mark.asyncio
 async def test_share_mul(test_runner):
     bit_length = 40  # Short key for testing
-    pp_elements = PreProcessedElements()
 
     async def _prog(context):
         p = TEST_POINTS[1]
 
         multiplier_ = Jubjub.Field(0)
-        m_bits = [pp_elements.get_bit(context)
+        m_bits = [context.preproc.get_bit(context)
                   for i in range(bit_length)]
 
         for idx, m in enumerate(m_bits):

--- a/tests/progs/test_mimc.py
+++ b/tests/progs/test_mimc.py
@@ -4,18 +4,20 @@ from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain, mimc_mpc_batch
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ['rands', 'triples', 'zeros', 'cubes']
-n, t = 3, 1
-k = 10000
+n, t = 4, 1
+k = 3500
 
 
 @mark.asyncio
-async def test_mimc(test_preprocessing, test_runner):
+async def test_mimc(test_runner):
+    pp_elements = PreProcessedElements()
 
     async def _prog(context):
-        x = test_preprocessing.elements.get_zero(context)
+        x = pp_elements.get_zero(context)
         field = GF(Subgroup.BLS12_381)
         key = field(15)
 
@@ -34,12 +36,14 @@ async def test_mimc(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_mimc_mpc_batch(test_preprocessing, test_runner):
+async def test_mimc_mpc_batch(test_runner):
     field = GF(Subgroup.BLS12_381)
     key = field(randint(0, field.modulus))
 
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
-        xs = [test_preprocessing.elements.get_rand(context) for _ in range(20)]
+        xs = [pp_elements.get_rand(context) for _ in range(20)]
 
         # Compute F_MiMC_mpc, mm - mimc_mpc
         mm = await mimc_mpc_batch(context, xs, key)

--- a/tests/progs/test_mimc.py
+++ b/tests/progs/test_mimc.py
@@ -4,7 +4,6 @@ from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain, mimc_mpc_batch
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ['rands', 'triples', 'zeros', 'cubes']
@@ -14,10 +13,8 @@ k = 3500
 
 @mark.asyncio
 async def test_mimc(test_runner):
-    pp_elements = PreProcessedElements()
-
     async def _prog(context):
-        x = pp_elements.get_zero(context)
+        x = context.preproc.get_zero(context)
         field = GF(Subgroup.BLS12_381)
         key = field(15)
 
@@ -40,10 +37,8 @@ async def test_mimc_mpc_batch(test_runner):
     field = GF(Subgroup.BLS12_381)
     key = field(randint(0, field.modulus))
 
-    pp_elements = PreProcessedElements()
-
     async def _prog(context):
-        xs = [pp_elements.get_rand(context) for _ in range(20)]
+        xs = [context.preproc.get_rand(context) for _ in range(20)]
 
         # Compute F_MiMC_mpc, mm - mimc_mpc
         mm = await mimc_mpc_batch(context, xs, key)

--- a/tests/progs/test_mimc_jubjub_pkc.py
+++ b/tests/progs/test_mimc_jubjub_pkc.py
@@ -1,5 +1,4 @@
 from pytest import mark
-from random import randint
 import asyncio
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
@@ -22,15 +21,15 @@ STANDARD_ARITHMETIC_MIXINS = [
 
 PREPROCESSING = ['rands', 'triples', 'zeros', 'cubes', 'bits']
 n, t = 4, 1
-k = 10000
+k = 1000
 
 
 @mark.asyncio
-async def test_mimc_jubjub_pkc(test_preprocessing, test_runner):
+async def test_mimc_jubjub_pkc(test_runner):
 
     field = GF(Subgroup.BLS12_381)
-    plaintext = [randint(0, field.modulus)]
-    seed = randint(0, field.modulus)
+    plaintext = [field.random().value]
+    seed = field.random().value
 
     async def _prog(context):
         # Key Generation

--- a/tests/progs/test_mimc_symmetric.py
+++ b/tests/progs/test_mimc_symmetric.py
@@ -4,7 +4,6 @@ from honeybadgermpc.field import GF
 from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 from honeybadgermpc.progs.mimc_symmetric import mimc_encrypt, mimc_decrypt
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ['rands', 'triples', 'zeros', 'cubes', 'bits']
@@ -17,10 +16,9 @@ async def test_mimc_symmetric(test_runner):
     field = GF(Subgroup.BLS12_381)
     plaintext = [randint(0, field.modulus)]
     key_ = field(randint(0, field.modulus))
-    pp_elements = PreProcessedElements()
 
     async def _prog(context):
-        key = pp_elements.get_zero(context) + key_
+        key = context.preproc.get_zero(context) + key_
 
         cipher = mimc_encrypt(key_, plaintext)
         decrypted_value = await mimc_decrypt(context, key, cipher)

--- a/tests/progs/test_mimc_symmetric.py
+++ b/tests/progs/test_mimc_symmetric.py
@@ -1,23 +1,23 @@
 from pytest import mark
 from random import randint
 from honeybadgermpc.field import GF
-from honeybadgermpc.mpc import PreProcessedElements, Subgroup
+from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 from honeybadgermpc.progs.mimc_symmetric import mimc_encrypt, mimc_decrypt
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ['rands', 'triples', 'zeros', 'cubes', 'bits']
-n, t = 3, 1
-k = 10000
+n, t = 4, 1
+k = 1000
 
 
 @mark.asyncio
-async def test_mimc_symmetric(test_preprocessing, test_runner):
-
-    pp_elements = PreProcessedElements()
+async def test_mimc_symmetric(test_runner):
     field = GF(Subgroup.BLS12_381)
     plaintext = [randint(0, field.modulus)]
     key_ = field(randint(0, field.modulus))
+    pp_elements = PreProcessedElements()
 
     async def _prog(context):
         key = pp_elements.get_zero(context) + key_

--- a/tests/progs/test_random_refinement.py
+++ b/tests/progs/test_random_refinement.py
@@ -1,14 +1,17 @@
 from pytest import mark
 from honeybadgermpc.progs.random_refinement import refine_randoms
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 @mark.parametrize("n, t, k", [(4, 1, 3), (4, 1, 4), (7, 2, 5)])
 @mark.asyncio
 async def test_random_refinement(
-        n, t, k, galois_field, polynomial, test_preprocessing, test_runner):
+        n, t, k, galois_field, polynomial, test_runner):
+
     async def _prog(context):
-        random_shares = [test_preprocessing.elements.get_rand(
-            context).v.value for i in range(k)]
+        pp_elements = PreProcessedElements()
+        random_shares = [pp_elements.get_rand(context).v.value
+                         for i in range(k)]
         refined_random_shares = refine_randoms(n, t, galois_field, random_shares)
         assert len(refined_random_shares) == k-t
         randoms = await context.ShareArray(refined_random_shares).open()

--- a/tests/progs/test_random_refinement.py
+++ b/tests/progs/test_random_refinement.py
@@ -1,6 +1,5 @@
 from pytest import mark
 from honeybadgermpc.progs.random_refinement import refine_randoms
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 @mark.parametrize("n, t, k", [(4, 1, 3), (4, 1, 4), (7, 2, 5)])
@@ -9,8 +8,7 @@ async def test_random_refinement(
         n, t, k, galois_field, polynomial, test_runner):
 
     async def _prog(context):
-        pp_elements = PreProcessedElements()
-        random_shares = [pp_elements.get_rand(context).v.value
+        random_shares = [context.preproc.get_rand(context).v.value
                          for i in range(k)]
         refined_random_shares = refine_randoms(n, t, galois_field, random_shares)
         assert len(refined_random_shares) == k-t

--- a/tests/progs/test_triple_refinement.py
+++ b/tests/progs/test_triple_refinement.py
@@ -1,16 +1,19 @@
 import asyncio
 from pytest import mark
 from honeybadgermpc.progs.triple_refinement import refine_triples
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 @mark.asyncio
 @mark.parametrize("n, t, k", [(4, 1, 3), (4, 1, 4), (7, 2, 5), (7, 2, 7)])
-async def test_triple_refinement(n, t, k, test_preprocessing, test_runner):
+async def test_triple_refinement(n, t, k, test_runner):
+    pp_elements = PreProcessedElements()
+
     async def _prog(context):
         _a, _b, _c = [], [], []
         # Every party needs its share of all the `N` triples' shares
         for _ in range(k):
-            p, q, pq = test_preprocessing.elements.get_triple(context)
+            p, q, pq = pp_elements.get_triples(context)
             _a.append(p.v.value), _b.append(q.v.value), _c.append(pq.v.value)
         p, q, pq = await refine_triples(context, _a, _b, _c)
         async def _open(x): return await context.ShareArray(x).open()

--- a/tests/progs/test_triple_refinement.py
+++ b/tests/progs/test_triple_refinement.py
@@ -1,19 +1,16 @@
 import asyncio
 from pytest import mark
 from honeybadgermpc.progs.triple_refinement import refine_triples
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 @mark.asyncio
 @mark.parametrize("n, t, k", [(4, 1, 3), (4, 1, 4), (7, 2, 5), (7, 2, 7)])
 async def test_triple_refinement(n, t, k, test_runner):
-    pp_elements = PreProcessedElements()
-
     async def _prog(context):
         _a, _b, _c = [], [], []
         # Every party needs its share of all the `N` triples' shares
         for _ in range(k):
-            p, q, pq = pp_elements.get_triples(context)
+            p, q, pq = context.preproc.get_triples(context)
             _a.append(p.v.value), _b.append(q.v.value), _c.append(pq.v.value)
         p, q, pq = await refine_triples(context, _a, _b, _c)
         async def _open(x): return await context.ShareArray(x).open()

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -16,7 +16,7 @@ async def test_open_shares():
     async def _prog(context):
         secrets = []
         for _ in range(number_of_secrets):
-            s = await pp_elements.get_zero(context).open()
+            s = await context.preproc.get_zero(context).open()
             assert s == 0
             secrets.append(s)
         print('[%d] Finished' % (context.myid,))
@@ -39,7 +39,7 @@ async def test_open_future_shares():
 
     async def _prog(context):
         e1_, e2_ = [
-            pp_elements.get_rand(context) for _ in range(2)]
+            context.preproc.get_rand(context) for _ in range(2)]
         e1, e2 = await asyncio.gather(*[e1_.open(), e2_.open()], return_exceptions=True)
 
         s_prod_f = e1_ * e2_

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -2,19 +2,21 @@ from pytest import mark
 from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 from honeybadgermpc.progs.mixins.constants import MixinConstants
+from honeybadgermpc.preprocessing import PreProcessedElements
 import asyncio
 
 
 @mark.asyncio
-async def test_open_shares(test_preprocessing):
+async def test_open_shares():
     n, t = 3, 1
     number_of_secrets = 100
-    test_preprocessing.generate("zeros", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("zeros", n, t)
 
     async def _prog(context):
         secrets = []
         for _ in range(number_of_secrets):
-            s = await test_preprocessing.elements.get_zero(context).open()
+            s = await pp_elements.get_zero(context).open()
             assert s == 0
             secrets.append(s)
         print('[%d] Finished' % (context.myid,))
@@ -29,16 +31,16 @@ async def test_open_shares(test_preprocessing):
 
 
 @mark.asyncio
-async def test_open_future_shares(test_preprocessing):
-    n, t = 3, 1
-
-    test_preprocessing.generate("rands", n, t)
-    test_preprocessing.generate("triples", n, t)
+async def test_open_future_shares():
+    n, t = 4, 1
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("rands", n, t)
+    pp_elements.generate("triples", n, t)
 
     async def _prog(context):
         e1_, e2_ = [
-            test_preprocessing.elements.get_rand(context, t) for _ in range(2)]
-        e1, e2 = await asyncio.gather(*[e1_.open(), e2_.open()])
+            pp_elements.get_rand(context) for _ in range(2)]
+        e1, e2 = await asyncio.gather(*[e1_.open(), e2_.open()], return_exceptions=True)
 
         s_prod_f = e1_ * e2_
         s_prod_f2 = s_prod_f * e1_

--- a/tests/test_offline_robust.py
+++ b/tests/test_offline_robust.py
@@ -143,4 +143,4 @@ async def test_get_triples(test_router, rust_field, n, t, b):
     assert triples.count(triples[0]) == n
     for i in range(0, len(triples[0]), 3):
         p, q, pq = triples[0][i:i+3]
-        assert p*q == p*q
+        assert p*q == p * q

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -13,7 +13,7 @@ async def test_get_triple():
 
     async def _prog(ctx):
         for _ in range(num_triples):
-            a_sh, b_sh, ab_sh = pp_elements.get_triples(ctx,)
+            a_sh, b_sh, ab_sh = ctx.preproc.get_triples(ctx,)
             a, b, ab = await a_sh.open(), await b_sh.open(), await ab_sh.open()
             assert a*b == ab
 
@@ -31,7 +31,7 @@ async def test_get_cube():
 
     async def _prog(ctx):
         for _ in range(num_cubes):
-            a1_sh, a2_sh, a3_sh = pp_elements.get_cubes(ctx)
+            a1_sh, a2_sh, a3_sh = ctx.preproc.get_cubes(ctx)
             a1, a2, a3 = await a1_sh.open(), await a2_sh.open(), await a3_sh.open()
             assert a1*a1 == a2
             assert a1*a2 == a3
@@ -50,7 +50,7 @@ async def test_get_zero():
 
     async def _prog(ctx):
         for _ in range(num_zeros):
-            x_sh = pp_elements.get_zero(ctx)
+            x_sh = ctx.preproc.get_zero(ctx)
             assert await x_sh.open() == 0
 
     program_runner = TaskProgramRunner(n, t)
@@ -69,7 +69,7 @@ async def test_get_rand():
         for _ in range(num_rands):
             # Nothing to assert here, just check if the
             # required number of rands are generated
-            pp_elements.get_rand(ctx)
+            ctx.preproc.get_rand(ctx)
 
     program_runner = TaskProgramRunner(n, t)
     program_runner.add(_prog)
@@ -84,7 +84,7 @@ async def test_get_bit():
     pp_elements.generate("bits", n, t)
 
     async def _prog(ctx):
-        shares = [pp_elements.get_bit(ctx,) for _ in range(num_bits)]
+        shares = [ctx.preproc.get_bit(ctx,) for _ in range(num_bits)]
         x = ctx.ShareArray(shares)
         x_ = await x.open()
         for i in x_:
@@ -105,7 +105,7 @@ async def test_get_powers():
 
     async def _prog(ctx):
         for i in range(nums):
-            powers = pp_elements.get_powers(ctx, i)
+            powers = ctx.preproc.get_powers(ctx, i)
             x = await powers[0].open()
             for i, power in enumerate(powers[1:]):
                 assert await power.open() == pow(x, i+2)
@@ -123,7 +123,7 @@ async def test_get_share():
     sid = pp_elements.generate_share(1, n, t, x)
 
     async def _prog(ctx):
-        x_sh = pp_elements.get_share(ctx, sid)
+        x_sh = ctx.preproc.get_share(ctx, sid)
         assert await x_sh.open() == x
 
     program_runner = TaskProgramRunner(n, t)
@@ -138,7 +138,7 @@ async def test_get_double_share():
     pp_elements.generate("double_shares", n, t)
 
     async def _prog(ctx):
-        r_t_sh, r_2t_sh = pp_elements.get_double_shares(ctx)
+        r_t_sh, r_2t_sh = ctx.preproc.get_double_shares(ctx)
         assert r_t_sh.t == ctx.t
         assert r_2t_sh.t == ctx.t*2
         await r_t_sh.open()
@@ -157,7 +157,7 @@ async def test_get_share_bits():
     pp_elements.generate("share_bits", n, t, k=1)
 
     async def _prog(ctx):
-        share, bits = pp_elements.get_share_bits(ctx)
+        share, bits = ctx.preproc.get_share_bits(ctx)
         opened_share = await share.open()
         opened_bits = await asyncio.gather(*[b.open() for b in bits])
         bit_value = int(''.join([str(b.value) for b in reversed(opened_bits)]), 2)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,17 +1,19 @@
 from pytest import mark
 from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.preprocessing import PreProcessedElements
 import asyncio
 
 
 @mark.asyncio
-async def test_get_triple(test_preprocessing):
+async def test_get_triple():
     n, t = 4, 1
     num_triples = 2
-    test_preprocessing.generate("triples", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("triples", n, t)
 
     async def _prog(ctx):
         for _ in range(num_triples):
-            a_sh, b_sh, ab_sh = test_preprocessing.elements.get_triple(ctx)
+            a_sh, b_sh, ab_sh = pp_elements.get_triples(ctx,)
             a, b, ab = await a_sh.open(), await b_sh.open(), await ab_sh.open()
             assert a*b == ab
 
@@ -21,14 +23,15 @@ async def test_get_triple(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_cube(test_preprocessing):
+async def test_get_cube():
     n, t = 4, 1
     num_cubes = 2
-    test_preprocessing.generate("cubes", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("cubes", n, t)
 
     async def _prog(ctx):
         for _ in range(num_cubes):
-            a1_sh, a2_sh, a3_sh = test_preprocessing.elements.get_cube(ctx)
+            a1_sh, a2_sh, a3_sh = pp_elements.get_cubes(ctx)
             a1, a2, a3 = await a1_sh.open(), await a2_sh.open(), await a3_sh.open()
             assert a1*a1 == a2
             assert a1*a2 == a3
@@ -39,14 +42,15 @@ async def test_get_cube(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_zero(test_preprocessing):
+async def test_get_zero():
     n, t = 4, 1
     num_zeros = 2
-    test_preprocessing.generate("zeros", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("zeros", n, t)
 
     async def _prog(ctx):
         for _ in range(num_zeros):
-            x_sh = test_preprocessing.elements.get_zero(ctx)
+            x_sh = pp_elements.get_zero(ctx)
             assert await x_sh.open() == 0
 
     program_runner = TaskProgramRunner(n, t)
@@ -55,16 +59,17 @@ async def test_get_zero(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_rand(test_preprocessing):
+async def test_get_rand():
     n, t = 4, 1
     num_rands = 2
-    test_preprocessing.generate("rands", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("rands", n, t)
 
     async def _prog(ctx):
         for _ in range(num_rands):
             # Nothing to assert here, just check if the
             # required number of rands are generated
-            test_preprocessing.elements.get_rand(ctx)
+            pp_elements.get_rand(ctx)
 
     program_runner = TaskProgramRunner(n, t)
     program_runner.add(_prog)
@@ -72,13 +77,14 @@ async def test_get_rand(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_bit(test_preprocessing):
+async def test_get_bit():
     n, t = 4, 1
     num_bits = 20
-    test_preprocessing.generate("bits", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("bits", n, t)
 
     async def _prog(ctx):
-        shares = [test_preprocessing.elements.get_bit(ctx) for _ in range(num_bits)]
+        shares = [pp_elements.get_bit(ctx,) for _ in range(num_bits)]
         x = ctx.ShareArray(shares)
         x_ = await x.open()
         for i in x_:
@@ -90,15 +96,16 @@ async def test_get_bit(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_powers(test_preprocessing):
+async def test_get_powers():
     n, t = 4, 1
+    pp_elements = PreProcessedElements()
     nums, num_powers = 2, 3
 
-    test_preprocessing.generate("powers", n, t, num_powers, nums)
+    pp_elements.generate_powers(num_powers, n,  t, nums)
 
     async def _prog(ctx):
         for i in range(nums):
-            powers = test_preprocessing.elements.get_powers(ctx, i)
+            powers = pp_elements.get_powers(ctx, i)
             x = await powers[0].open()
             for i, power in enumerate(powers[1:]):
                 assert await power.open() == pow(x, i+2)
@@ -109,13 +116,14 @@ async def test_get_powers(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_share(test_preprocessing):
+async def test_get_share():
     n, t = 4, 1
     x = 41
-    sid = test_preprocessing.generate("share", n, t, x)
+    pp_elements = PreProcessedElements()
+    sid = pp_elements.generate_share(1, n, t, x)
 
     async def _prog(ctx):
-        x_sh = test_preprocessing.elements.get_share(ctx, sid)
+        x_sh = pp_elements.get_share(ctx, sid)
         assert await x_sh.open() == x
 
     program_runner = TaskProgramRunner(n, t)
@@ -124,12 +132,13 @@ async def test_get_share(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_double_share(test_preprocessing):
+async def test_get_double_share():
     n, t = 9, 2
-    test_preprocessing.generate("double_shares", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("double_shares", n, t)
 
     async def _prog(ctx):
-        r_t_sh, r_2t_sh = test_preprocessing.elements.get_double_share(ctx)
+        r_t_sh, r_2t_sh = pp_elements.get_double_shares(ctx)
         assert r_t_sh.t == ctx.t
         assert r_2t_sh.t == ctx.t*2
         await r_t_sh.open()
@@ -142,12 +151,13 @@ async def test_get_double_share(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_share_bits(test_preprocessing):
+async def test_get_share_bits():
     n, t, = 4, 1
-    test_preprocessing.generate("share_bits", n, t, k=1)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate("share_bits", n, t, k=1)
 
     async def _prog(ctx):
-        share, bits = test_preprocessing.elements.get_share_bits(ctx)
+        share, bits = pp_elements.get_share_bits(ctx)
         opened_share = await share.open()
         opened_bits = await asyncio.gather(*[b.open() for b in bits])
         bit_value = int(''.join([str(b.value) for b in reversed(opened_bits)]), 2)


### PR DESCRIPTION
This PR refactors preprocessing into a more plugin based model. This also changes the way we cache elements-- when asked to generate elements, we simply make sure that the cache has at least that amount of elements. If asked to append, this will append to the existing preprocessing file, otherwise, it will overwrite the existing data.

We also turn preprocessing into a singleton to prevent overuse of memory.

A nice side effect is that since this doesn't needlessly generate values, we were able to cut testing time by 33% on my machine (300s -> 200s). 

Finally, this fixes issues where the preprocessing would run out due to the execution of other tests as the caching wasn't being properly updated.