### PR TITLE
Refactor preprocessing to improve caching and use mixins

### DIFF
--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -10,8 +10,7 @@ if [ "${BUILD}" == "tests" ]; then
         --cov-report=term-missing \
         --cov-report=xml \
         -Wignore::DeprecationWarning \
-        -nauto \
-        --dist=loadfile
+        -nauto 
 
     IMAGE_NAME=$(docker ps -alq --format "{{.Names}}")
     docker cp $IMAGE_NAME:/usr/src/HoneyBadgerMPC/coverage.xml .

--- a/apps/asynchromix/butterfly_network.py
+++ b/apps/asynchromix/butterfly_network.py
@@ -1,17 +1,12 @@
 import asyncio
 import logging
 from math import log
-from honeybadgermpc.preprocessing import (
-    PreProcessedElements,
-    wait_for_preprocessing,
-    preprocessing_done,
-)
+from honeybadgermpc.preprocessing import PreProcessedElements
 from time import time
 
 
 async def batch_switch(ctx, xs, ys, n):
-    pp_elements = PreProcessedElements()
-    sbits = [pp_elements.get_one_minus_one_rand(ctx).v for _ in range(n // 2)]
+    sbits = [ctx.preproc.get_one_minus_ones(ctx).v for _ in range(n // 2)]
     ns = [1 / ctx.field(2) for _ in range(n // 2)]
 
     assert len(xs) == len(ys) == len(sbits) == n // 2
@@ -59,8 +54,11 @@ async def iterated_butterfly_network(ctx, inputs, k):
 
 async def butterfly_network_helper(ctx, **kwargs):
     k = kwargs["k"]
-    pp_elements = PreProcessedElements()
-    inputs = [pp_elements.get_rand(ctx).v for _ in range(k)]
+
+    inputs = kwargs["inputs"]
+    if inputs is None:
+        inputs = [ctx.preproc.get_rand(ctx).v for _ in range(k)]
+
     logging.info(f"[{ctx.myid}] Running permutation network.")
     shuffled = await iterated_butterfly_network(ctx, inputs, k)
     if shuffled is not None:
@@ -88,6 +86,9 @@ if __name__ == "__main__":
 
     k = int(HbmpcConfig.extras["k"])
 
+    pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
+
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
@@ -95,20 +96,20 @@ if __name__ == "__main__":
         if not HbmpcConfig.skip_preprocessing:
             if HbmpcConfig.my_id == 0:
                 NUM_SWITCHES = k * int(log(k, 2)) ** 2
-                pp_elements = PreProcessedElements()
-                pp_elements.generate_one_minus_one_rands(
+                pp_elements.generate_one_minus_ones(
                     NUM_SWITCHES, HbmpcConfig.N, HbmpcConfig.t
                 )
                 pp_elements.generate_triples(
                     2 * NUM_SWITCHES, HbmpcConfig.N, HbmpcConfig.t
                 )
                 pp_elements.generate_rands(k, HbmpcConfig.N, HbmpcConfig.t)
-                preprocessing_done()
+                pp_elements.preprocessing_done()
             else:
-                loop.run_until_complete(wait_for_preprocessing())
+                loop.run_until_complete(pp_elements.wait_for_preprocessing())
 
         loop.run_until_complete(
             _run(HbmpcConfig.peers, HbmpcConfig.N, HbmpcConfig.t, HbmpcConfig.my_id)
         )
     finally:
         loop.close()
+        pp_elements.clear_preprocessing()

--- a/apps/asynchromix/powermixing.py
+++ b/apps/asynchromix/powermixing.py
@@ -4,8 +4,7 @@ from time import time
 from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.field import GF
 from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.preprocessing import PreProcessedElements, PreProcessingConstants
-from honeybadgermpc.preprocessing import wait_for_preprocessing, preprocessing_done
+from honeybadgermpc.preprocessing import PreProcessedElements
 import logging
 
 
@@ -13,12 +12,10 @@ async def all_secrets_phase1(context, **kwargs):
     k, file_prefixes = kwargs["k"], kwargs["file_prefixes"]
     as_, a_minus_b_shares, all_powers = [], [], []
 
-    pp_elements = PreProcessedElements()
-
     stime = time()
     for i in range(k):
-        a = pp_elements.get_rand(context)
-        powers = pp_elements.get_powers(context, i)
+        a = context.preproc.get_rand(context)
+        powers = context.preproc.get_powers(context, i)
         a_minus_b_shares.append(a - powers[0])
         as_.append(a)
         all_powers.append(powers)
@@ -36,7 +33,7 @@ async def all_secrets_phase1(context, **kwargs):
     stime = time()
     for i in range(k):
         file_name = f"{file_prefixes[i]}-{context.myid}.input"
-        file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{file_name}"
+        file_path = f"{context.preproc.data_directory}{file_name}"
         with open(file_path, "w") as f:
             print(context.field.modulus, file=f)
             print(as_[i].v.value, file=f)
@@ -50,9 +47,9 @@ async def all_secrets_phase1(context, **kwargs):
 
 async def phase2(node_id, run_id, file_prefix):
     input_file_name = f"{file_prefix}-{node_id}.input"
-    input_file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{input_file_name}"
+    input_file_path = f"{PreProcessedElements.DEFAULT_DIRECTORY}{input_file_name}"
     sum_file_name = f"power-{run_id}_{node_id}.sums"
-    sum_file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{sum_file_name}"
+    sum_file_path = f"{PreProcessedElements.DEFAULT_DIRECTORY}{sum_file_name}"
 
     # NOTE The binary `compute-power-sums` is generated via the command
     # make -C apps/shuffle/cpp
@@ -76,7 +73,7 @@ async def run_command_sync(command):
 async def phase3(context, **kwargs):
     k, run_id = kwargs["k"], kwargs["run_id"]
     sum_file_name = f"power-{run_id}_{context.myid}.sums"
-    sum_file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{sum_file_name}"
+    sum_file_path = f"{context.preproc.data_directory}{sum_file_name}"
     sum_shares = []
 
     bench_logger = logging.LoggerAdapter(
@@ -170,8 +167,13 @@ async def async_mixing_in_processes(network_info, n, t, k, run_id, node_id):
 if __name__ == "__main__":
     from honeybadgermpc.config import HbmpcConfig
 
+    HbmpcConfig.load_config()
+
     run_id = HbmpcConfig.extras["run_id"]
     k = int(HbmpcConfig.extras["k"])
+
+    pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
 
     asyncio.set_event_loop(asyncio.new_event_loop())
     loop = asyncio.get_event_loop()
@@ -182,13 +184,12 @@ if __name__ == "__main__":
             field = GF(Subgroup.BLS12_381)
             a_s = [field(i) for i in range(1000 + k, 1000, -1)]
 
-            pp_elements = PreProcessedElements()
             if HbmpcConfig.my_id == 0:
                 pp_elements.generate_rands(k, HbmpcConfig.N, HbmpcConfig.t)
                 pp_elements.generate_powers(k, HbmpcConfig.N, HbmpcConfig.t, k)
-                preprocessing_done()
+                pp_elements.preprocessing_done()
             else:
-                loop.run_until_complete(wait_for_preprocessing())
+                loop.run_until_complete(pp_elements.wait_for_preprocessing())
 
         loop.run_until_complete(
             async_mixing_in_processes(

--- a/apps/tutorial/hbmpc-tutorial-1.py
+++ b/apps/tutorial/hbmpc-tutorial-1.py
@@ -3,12 +3,7 @@ hbMPC tutorial 1. Running sample MPC programs in the testing simulator
 """
 import asyncio
 from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.progs.mixins.dataflow import (
-    Share,
-    ShareArray,
-    ShareFuture,
-    GFElementFuture,
-)
+from honeybadgermpc.progs.mixins.dataflow import Share
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements,
 )
@@ -85,7 +80,6 @@ def dot_product(ctx, x_shares, y_shares):
 
 async def prog(ctx):
     # Test with random sharings of hardcoded values
-    ctx.preproc = FakePreProcessedElements()
     x = ctx.Share(5) + ctx.preproc.get_zero(ctx)
     y = ctx.Share(7) + ctx.preproc.get_zero(ctx)
     xy = await beaver_multiply(ctx, x, y)

--- a/apps/tutorial/hbmpc-tutorial-2.py
+++ b/apps/tutorial/hbmpc-tutorial-2.py
@@ -1,4 +1,4 @@
-""" 
+"""
 hbMPC tutorial 2.
 
 Instructions:
@@ -11,16 +11,7 @@ import asyncio
 import logging
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements,
-    wait_for_preprocessing,
-    preprocessing_done,
 )
-from honeybadgermpc.progs.mixins.dataflow import (
-    Share,
-    ShareArray,
-    ShareFuture,
-    GFElementFuture,
-)
-from honeybadgermpc.utils.typecheck import TypeCheck
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     MixinConstants,
     BeaverMultiply,
@@ -39,7 +30,6 @@ async def dot_product(ctx, xs, ys):
 
 async def prog(ctx, k=50):
     # Computing a dot product by MPC (k openings)
-    ctx.preproc = FakePreProcessedElements()
     xs = [ctx.preproc.get_bit(ctx) for _ in range(k)]
     ys = [ctx.preproc.get_bit(ctx) for _ in range(k)]
     logging.info(f"[{ctx.myid}] Running prog 1.")
@@ -64,11 +54,12 @@ async def _run(peers, n, t, my_id):
 if __name__ == "__main__":
     from honeybadgermpc.config import HbmpcConfig
     import sys
-    import os
 
     if not HbmpcConfig.peers:
         print(
-            f"WARNING: the $CONFIG_PATH environment variable wasn't set. Please run this file with `scripts/launch-tmuxlocal.sh apps/tutorial/hbmpc-tutorial-2.py conf/mpc/local`"
+            f"WARNING: the $CONFIG_PATH environment variable wasn't set. "
+            f"Please run this file with `scripts/launch-tmuxlocal.sh "
+            f"apps/tutorial/hbmpc-tutorial-2.py conf/mpc/local`"
         )
         sys.exit(1)
 
@@ -81,9 +72,9 @@ if __name__ == "__main__":
             pp_elements = FakePreProcessedElements()
             pp_elements.generate_bits(k, HbmpcConfig.N, HbmpcConfig.t)
             pp_elements.generate_triples(k, HbmpcConfig.N, HbmpcConfig.t)
-            preprocessing_done()
+            pp_elements.preprocessing_done()
         else:
-            loop.run_until_complete(wait_for_preprocessing())
+            loop.run_until_complete(pp_elements.wait_for_preprocessing())
 
         loop.run_until_complete(
             _run(HbmpcConfig.peers, HbmpcConfig.N, HbmpcConfig.t, HbmpcConfig.my_id)

--- a/benchmark/test_benchmark_batch_opening.py
+++ b/benchmark/test_benchmark_batch_opening.py
@@ -5,12 +5,12 @@ from pytest import mark
     "n,t,k",
     [(4, 1, 2 ** i) for i in range(3, 11)] + [(7, 2, 2 ** i) for i in range(3, 11)],
 )
-def test_benchmark_batch_opening(benchmark_runner, test_preprocessing, n, t, k):
+def test_benchmark_batch_opening(benchmark_runner, n, t, k):
     num_rands = sum([2 ** i for i in range(3, 11)]) * n
 
     async def _prog(context):
         await context.ShareArray(
-            [test_preprocessing.elements.get_rand(context) for _ in range(k)]
+            [context.preproc.get_rand(context) for _ in range(k)]
         ).open()
 
     benchmark_runner(_prog, n, t, ["rands"], num_rands)

--- a/benchmark/test_benchmark_jubjub.py
+++ b/benchmark/test_benchmark_jubjub.py
@@ -87,13 +87,11 @@ def test_benchmark_shared_point_montgomery_mul(benchmark_runner, multiplier):
 
 
 @mark.parametrize("bit_length", list(range(64, 257, 64)))
-def test_benchmark_share_mul(bit_length, test_preprocessing, benchmark_runner):
+def test_benchmark_share_mul(bit_length, benchmark_runner):
     p = TEST_POINT
 
     async def _prog(context):
-        m_bits = [
-            test_preprocessing.elements.get_bit(context) for i in range(bit_length)
-        ]
+        m_bits = [context.preproc.get_bit(context) for i in range(bit_length)]
 
         multiplier_ = Jubjub.Field(0)
         for idx, m_b in enumerate(m_bits):

--- a/benchmark/test_benchmark_mimc.py
+++ b/benchmark/test_benchmark_mimc.py
@@ -33,9 +33,9 @@ TEST_KEY = TEST_FIELD(randint(0, TEST_FIELD.modulus))
 
 # All iterations take around 30min total.
 @mark.parametrize("batch_size", [10 ** i for i in range(4)])
-def test_benchmark_mimc_mpc_batch(batch_size, test_preprocessing, benchmark_runner):
+def test_benchmark_mimc_mpc_batch(batch_size, benchmark_runner):
     async def _prog(context):
-        xs = [test_preprocessing.elements.get_rand(context) for _ in range(batch_size)]
+        xs = [context.preproc.get_rand(context) for _ in range(batch_size)]
         await mimc_mpc_batch(context, xs, TEST_KEY)
 
     benchmark_runner(_prog, n, t, PREPROCESSING, k)

--- a/benchmark/test_benchmark_preprocessing.py
+++ b/benchmark/test_benchmark_preprocessing.py
@@ -5,10 +5,12 @@ from honeybadgermpc.preprocessing import PreProcessedElements
 @mark.parametrize("n,t,k", [(4, 1, 1024), (16, 5, 512), (50, 15, 256)])
 def test_benchmark_generate_rands(benchmark, n, t, k):
     pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
     benchmark(pp_elements.generate_rands, k, n, t)
 
 
 @mark.parametrize("n,t,k,z", [(4, 1, 64, 64), (16, 5, 32, 32), (61, 20, 32, 32)])
 def test_benchmark_generate_powers(benchmark, n, t, k, z):
     pp_elements = PreProcessedElements()
+    pp_elements.clear_preprocessing()
     benchmark(pp_elements.generate_powers, k, n, t, z)

--- a/honeybadgermpc/broadcast/crypto/boldyreva.py
+++ b/honeybadgermpc/broadcast/crypto/boldyreva.py
@@ -84,8 +84,8 @@ class TBLSPublicKey(object):
 
     def __eq__(self, other):
         return (
-            self.l == other.l  # noqa: E741
-            and self.k == other.k
+            self.l == other.l      # noqa: E741
+            and self.k == other.k  # noqa: E741
             and self.VK == other.VK
             and self.VKs == other.VKs
         )

--- a/honeybadgermpc/mpc.py
+++ b/honeybadgermpc/mpc.py
@@ -21,7 +21,9 @@ from .exceptions import HoneyBadgerMPCError
 
 
 class Mpc(object):
-    def __init__(self, sid, n, t, myid, send, recv, prog, config, **prog_args):
+    def __init__(
+        self, sid, n, t, myid, send, recv, prog, config, preproc=None, **prog_args
+    ):
         # Parameters for robust MPC
         # Note: tolerates min(t,N-t) crash faults
         assert type(n) is int and type(t) is int
@@ -33,6 +35,7 @@ class Mpc(object):
         self.field = GF(Subgroup.BLS12_381)
         self.poly = polynomials_over(self.field)
         self.config = config
+        self.preproc = preproc if preproc is not None else PreProcessedElements()
 
         # send(j, o): sends object o to party j with (current sid)
         # recv(): returns (j, o) from party j
@@ -305,9 +308,8 @@ class TaskProgramRunner(ProgramRunner):
 
 
 async def test_batchopening(context):
-    pp_elements = PreProcessedElements()
     # Demonstrates use of ShareArray batch interface
-    xs = [pp_elements.get_zero(context) + context.Share(i) for i in range(100)]
+    xs = [context.preproc.get_zero(context) + context.Share(i) for i in range(100)]
     xs = context.ShareArray(xs)
     xs_ = await xs.open()
     for i, x in enumerate(xs_):
@@ -317,14 +319,13 @@ async def test_batchopening(context):
 
 
 async def test_prog1(context):
-    pp_elements = PreProcessedElements()
     # Example of Beaver multiplication
-    x = pp_elements.get_zero(context) + context.Share(10)
+    x = context.preproc.get_zero(context) + context.Share(10)
     # x = context.Share(10)
-    y = pp_elements.get_zero(context) + context.Share(15)
+    y = context.preproc.get_zero(context) + context.Share(15)
     # y = context.Share(15)
 
-    a, b, ab = pp_elements.get_triple(context)
+    a, b, ab = context.preproc.get_triples(context)
     # assert await a.open() * await b.open() == await ab.open()
 
     d = (x - a).open()
@@ -347,8 +348,7 @@ async def test_prog1(context):
 
 
 async def test_prog2(context):
-    pp_elements = PreProcessedElements()
-    shares = [pp_elements.get_zero(context) for _ in range(1000)]
+    shares = [context.preproc.get_zero(context) for _ in range(1000)]
     for share in shares[:100]:
         s = await share.open()
         assert s == 0

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -1,381 +1,670 @@
 import logging
 import asyncio
+import re
 import os
+from os import makedirs, listdir
+from os.path import isfile, join
 from uuid import uuid4
 from random import randint
-from os import makedirs
+from collections import defaultdict
+from itertools import chain
+from enum import Enum
+from abc import ABC, abstractmethod
+from shutil import rmtree
+
 from .field import GF
 from .polynomial import polynomials_over
 from .ntl import vandermonde_batch_evaluate
 from .elliptic_curve import Subgroup
 
 
-class PreProcessingConstants(object):
+class PreProcessingConstants(Enum):
     SHARED_DATA_DIR = "sharedata/"
-    TRIPLES_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}triples"
-    CUBES_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}cubes"
-    ZEROS_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}zeros"
-    RANDS_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}rands"
-    BITS_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}bits"
-    POWERS_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}powers"
-    SHARES_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}specific_share"
-    ONE_MINUS_ONE_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}one_minus_one"
-    DOUBLE_SHARES_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}double_shares"
     READY_FILE_NAME = f"{SHARED_DATA_DIR}READY"
-    SHARE_BITS_FILE_NAME_PREFIX = f"{SHARED_DATA_DIR}share_bits"
+    TRIPLES = "triples"
+    CUBES = "cubes"
+    ZEROS = "zeros"
+    RANDS = "rands"
+    BITS = "bits"
+    POWERS = "powers"
+    SHARES = "share"
+    ONE_MINUS_ONE = "one_minus_one"
+    DOUBLE_SHARES = "double_shares"
+    SHARE_BITS = "share_bits"
+
+    def __str__(self):
+        return self.value
 
 
-async def wait_for_preprocessing():
-    while not os.path.exists(f"{PreProcessingConstants.SHARED_DATA_DIR}READY"):
-        logging.info(
-            f"waiting for preprocessing {PreProcessingConstants.READY_FILE_NAME}"
-        )
-        await asyncio.sleep(1)
+class PreProcessingMixin(ABC):
+    """ Abstract base class of preprocessing mixins.
+    The interface exposed is composed of a few parts:
+    - metadata:
+        - _preprocessing_stride dictates how many values are needed per element
+          when retrieving preprocessing
+        - preprocessing_name dictates the type of preprocessing-- e.g. "rands",
+          "triples", etc.
+            - file_prefix uses this to determine the filename to store preprocessed
+              values in.
+        - min_count returns the minimal amount of preprocessing remaining for a
+          given n, t combination.
+    - generation:
+        - generate_values is the public interface to generate preprocessing values from
+          the mixin
+        - _generate_polys is the private interface for doing the same thing, which is
+          what is overridden by subclasses.
+    - retrieval:
+        - get_value is the public interface to retrieve a value from preprocessing
+        - _get_value is the private interface for doing the same thing, which is what is
+          overridden by subclasses
+    """
 
+    def __init__(self, field, poly, data_dir):
+        self.field = field
+        self.poly = poly
+        self.cache = defaultdict(chain)
+        self.count = defaultdict(int)
+        self.data_dir = data_dir
+        self._refresh_cache()
 
-def clear_preprocessing():
-    import shutil
+    @property
+    def file_prefix(self):
+        """ Beginning prefix of filenames storing preprocessing values for this mixin
+        """
+        return f"{self.data_dir}{self.preprocessing_name}"
 
-    try:
-        shutil.rmtree(f"{PreProcessingConstants.SHARED_DATA_DIR}")
-    except FileNotFoundError:
-        pass  # not a problem
+    def min_count(self, n, t):
+        """ Returns the minimum number of preprocessing stored in the cache across all
+        of the keys with the given n, t values.
+        """
+        counts = []
+        for (id_, n_, t_) in self.count:
+            if (n_, t_) == (n, t):
+                counts.append(self.count[id_, n_, t_])
 
+        if len(counts) == 0:
+            return 0
 
-def preprocessing_done():
-    os.mknod(PreProcessingConstants.READY_FILE_NAME)
+        return min(counts) // self._preprocessing_stride
 
-
-class PreProcessedElements(object):
-    def __init__(self):
-        self.field = GF(Subgroup.BLS12_381)
-        self.poly = polynomials_over(self.field)
-        self._bit_length = self.field.modulus.bit_length()
-        self._triples = {}
-        self._cubes = {}
-        self._zeros = {}
-        self._rands = {}
-        self._bits = {}
-        self._share_bits = {}
-        self._one_minus_one_rands = {}
-        self._double_shares = {}
-
-    def _read_share_values_from_file(self, file_name):
-        with open(file_name, "r") as f:
-            lines = iter(f)
-
-            # first line: field modulus
-            modulus = int(next(lines))
-            assert self.field.modulus == modulus
-
-            # skip 2nd and 3rd line - share degree and id
-            next(lines), next(lines)
-
-            # remaining lines: shared values
-            return [int(line) for line in lines]
-
-    def _read_share_bit_values_from_file(self, file_name):
-        """ Given a file written using _write_share_bits_to_file, read the
-        file and return a list of tuples of shares with a list of their bit-sharings.
+    def get_value(self, context, *args, **kwargs):
+        """ Given an MPC context, retrieve one preprocessing value.
 
         args:
-            file_name (str): filename to read from
+            context: MPC context to use when fetching the value
+
+        outputs:
+            Preprocessing value for this mixin
+        """
+        key = (context.myid, context.N, context.t)
+
+        to_return, used = self._get_value(context, key, *args, **kwargs)
+        self.count[key] -= used
+
+        return to_return
+
+    def _read_preprocessing_file(self, file_name):
+        """ Given the filename of the preprocessing file to read, fetch all of the
+        values stored in the preprocessing file.
+        """
+        with open(file_name, "r") as f:
+            lines = f.read().splitlines()
+            values = list(map(int, lines))
+            assert len(values) >= 3
+
+            modulus = values[0]
+            assert modulus == self.field.modulus, (
+                f"Expected file "
+                f"to have modulus {self.field.modulus}, but found {modulus}"
+            )
+
+            # The second and third lines of the file contain the degree and context id
+            # correspondingly.
+            return values[3:]
+
+    def _write_preprocessing_file(
+        self, file_name, degree, context_id, values, append=False
+    ):
+        """ Write the values to the preprocessing file given by the filename.
+        When append is true, this will append to an existing file, otherwise, it will
+        overwrite.
+        """
+        if not os.path.isfile(file_name):
+            append = False
+
+        if append:
+            with open(file_name, "r") as f:
+                meta = tuple(int(f.readline()) for _ in range(3))
+                expected_meta = (self.field.modulus, degree, context_id)
+                assert meta == expected_meta, (
+                    f"File {file_name} "
+                    f"expected to have metadata {expected_meta}, but had {meta}"
+                )
+
+            f = open(file_name, "a")
+        else:
+            f = open(file_name, "w")
+            print(self.field.modulus, degree, context_id, file=f, sep="\n")
+
+        print(*values, file=f, sep="\n")
+        f.close()
+
+    def build_filename(self, n, t, context_id, prefix=None):
+        """ Given a file prefix, and metadata, return the filename to put
+        the shares in.
+
+        args:
+            n: Value of n used in preprocessing
+            t: Value of t used in preprocessing
+            context_id: myid of the mpc context we're preprocessing for.
+            prefix: filename prefix, e.g. "sharedata/triples".
+                Defaults to self.file_prefix
 
         output:
-            Returns a list of tuples, where the first element of each tuple is
-            the value of a share, and the second element is a list of values of
-            the shares that compose the bitwise sharing of the share.
-            Note: bits are given LSB first
+            Filename to use
         """
-        values = self._read_share_values_from_file(file_name)
-        assert len(values) % (self._bit_length + 1) == 0
+        if prefix is None:
+            prefix = self.file_prefix
 
-        stride = self._bit_length + 1
-        share_bits = [
-            (values[i * stride], values[i * stride + 1 : (i + 1) * stride])
-            for i in range(len(values) // stride)
-        ]
+        return f"{prefix}_{n}_{t}-{context_id}.share"
 
-        return share_bits
+    def _parse_file_name(self, file_name):
+        """ Given a potential filename, return (n, t, context_id) of the
+        file if it's a valid file, otherwise, return None
+        """
+        if not file_name.startswith(self.file_prefix):
+            return None
 
-    def _write_shares_to_file(self, f, degree, myid, shares):
-        """ Given a list of field elements representing shares,
-        write their values to file f.
+        reg = re.compile(f"{self.file_prefix}_(\\d+)_(\\d+)-(\\d+).share")
+        res = reg.search(file_name)
+        if res is None:
+            return None
+
+        if len(res.groups()) != 3:
+            return None
+
+        return tuple(map(int, res.groups()))
+
+    def _refresh_cache(self):
+        """ Refreshes the cache by reading in sharedata files, and
+        updating the cache values and count variables.
+        """
+        self.cache = defaultdict(chain)
+        self.count = defaultdict(int)
+
+        for f in listdir(self.data_dir):
+            file_name = join(self.data_dir, f)
+            if not isfile(file_name):
+                continue
+
+            groups = self._parse_file_name(file_name)
+            if groups is None:
+                continue
+
+            (n, t, context_id) = groups
+            key = (context_id, n, t)
+            values = self._read_preprocessing_file(file_name)
+
+            self.cache[key] = chain(values)
+            self.count[key] = len(values)
+
+    def _write_polys(self, n, t, polys, append=False, prefix=None):
+        """ Given a file prefix, a list of polynomials, and associated n, t values,
+        write the preprocessing for the share values represented by the polnomials.
 
         args:
-            f (file): file to write shares to
-            degree (int): degree of polynomial used to generate shares
-            myid (int): id the shares belong to
-            shares (list): list of GFElements representing share values
+            prefix: prefix to use when writing the file
+            n: number of nodes this is preprocessing for
+            t: number of faults tolerated by this preprocessing
+            polys: polynomials corresponding to secret share values to write
+            append: Whether or not to append shares to an existing file, or to overwrite.
         """
-        content = f"{self.field.modulus}\n{degree}\n{myid}\n"
-        for share in shares:
-            content += f"{share.value}\n"
-
-        f.write(content)
-
-    def _create_sharedata_dir_if_not_exists(self):
-        makedirs(PreProcessingConstants.SHARED_DATA_DIR, exist_ok=True)
-
-    ##############################
-    # MPC program access to shares
-    ##############################
-
-    def get_triple(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._triples:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = (
-                f"{PreProcessingConstants.TRIPLES_FILE_NAME_PREFIX}{file_suffix}"
-            )
-            self._triples[key] = iter(self._read_share_values_from_file(file_path))
-        try:
-            a = ctx.Share(next(self._triples[key]))
-            b = ctx.Share(next(self._triples[key]))
-            ab = ctx.Share(next(self._triples[key]))
-            return a, b, ab
-        except StopIteration:
-            print("STOP ITERATION TRIPLES")
-            raise StopIteration(f"preprocess underrun: TRIPLES")
-
-    def get_cube(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._cubes:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.CUBES_FILE_NAME_PREFIX}{file_suffix}"
-            self._cubes[key] = iter(self._read_share_values_from_file(file_path))
-        a1 = ctx.Share(next(self._cubes[key]))
-        a2 = ctx.Share(next(self._cubes[key]))
-        a3 = ctx.Share(next(self._cubes[key]))
-        return a1, a2, a3
-
-    def get_zero(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._zeros:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.ZEROS_FILE_NAME_PREFIX}{file_suffix}"
-            self._zeros[key] = iter(self._read_share_values_from_file(file_path))
-        return ctx.Share(next(self._zeros[key]))
-
-    def get_rand(self, ctx, t=None):
-        t = t if t is not None else ctx.t
-        key = (ctx.myid, ctx.N, t)
-        if key not in self._rands:
-            file_suffix = f"_{ctx.N}_{t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.RANDS_FILE_NAME_PREFIX}{file_suffix}"
-            self._rands[key] = iter(self._read_share_values_from_file(file_path))
-        return ctx.Share(next(self._rands[key]), t)
-
-    def get_bit(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._bits:
-            file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            file_path = f"{PreProcessingConstants.BITS_FILE_NAME_PREFIX}{file_suffix}"
-            self._bits[key] = iter(self._read_share_values_from_file(file_path))
-        return ctx.Share(next(self._bits[key]))
-
-    def get_one_minus_one_rand(self, ctx):
-        file_suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-        fpath = f"{PreProcessingConstants.ONE_MINUS_ONE_FILE_NAME_PREFIX}{file_suffix}"
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._one_minus_one_rands:
-            self._one_minus_one_rands[key] = iter(
-                self._read_share_values_from_file(fpath)
-            )
-        try:
-            return ctx.Share(next(self._one_minus_one_rands[key]))
-        except StopIteration:
-            print("STOP ITERATION ONE_MINUS_ONE")
-            raise StopIteration(f"preprocess underrun: ONE_MINUS_ONE")
-
-    def get_powers(self, ctx, pid):
-        file_suffix = f"_{pid}_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-        return list(
-            map(
-                ctx.Share,
-                self._read_share_values_from_file(
-                    f"{PreProcessingConstants.POWERS_FILE_NAME_PREFIX}{file_suffix}"
-                ),
-            )
-        )
-
-    def get_share(self, ctx, sid, t=None):
-        if t is None:
-            t = ctx.t
-        file_suffix = f"_{sid}_{ctx.N}_{t}-{ctx.myid}.share"
-        share_values = self._read_share_values_from_file(
-            f"{PreProcessingConstants.SHARES_FILE_NAME_PREFIX}{file_suffix}"
-        )
-        return ctx.Share(share_values[0], t)
-
-    def get_double_share(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._double_shares:
-            suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            path = f"{PreProcessingConstants.DOUBLE_SHARES_FILE_NAME_PREFIX}{suffix}"
-            self._double_shares[key] = iter(self._read_share_values_from_file(path))
-        r_t = ctx.Share(next(self._double_shares[key]))
-        r_2t = ctx.Share(next(self._double_shares[key]), 2 * ctx.t)
-        return r_t, r_2t
-
-    def get_share_bits(self, ctx):
-        key = (ctx.myid, ctx.N, ctx.t)
-        if key not in self._share_bits:
-            suffix = f"_{ctx.N}_{ctx.t}-{ctx.myid}.share"
-            path = f"{PreProcessingConstants.SHARE_BITS_FILE_NAME_PREFIX}{suffix}"
-            self._share_bits[key] = iter(self._read_share_bit_values_from_file(path))
-
-        share_val, bit_vals = next(self._share_bits[key])
-        share = ctx.Share(share_val)
-        bits = [ctx.Share(val) for val in bit_vals]
-
-        return share, bits
-
-    #########################
-    # Store the Preprocessing
-    #########################
-
-    def write_shares(self, ctx, file_name_prefix, degree, shares):
-        with open(
-            "%s_%d_%d-%d.share" % (file_name_prefix, ctx.N, ctx.t, ctx.myid), "w"
-        ) as f:
-            self._write_shares_to_file(f, degree, ctx.myid, shares)
-
-    def write_triples(self, ctx, triples):
-        trips = []
-        for a, b, ab in triples:
-            trips += (a, b, ab)
-        prefix = PreProcessingConstants.TRIPLES_FILE_NAME_PREFIX
-        self.write_shares(ctx, prefix, ctx.t, trips)
-
-    def write_one_minus_one(self, ctx, shares):
-        prefix = PreProcessingConstants.ONE_MINUS_ONE_FILE_NAME_PREFIX
-        self.write_shares(ctx, prefix, ctx.t, shares)
-
-    ####################
-    # Fake Preprocessing
-    ####################
-    """
-    Only use generate_{preproctype} to create fake preprocessing,
-    useful for local experiments for just the online phase.
-    """
-
-    def _write_polys(self, file_name_prefix, n, t, polys):
         polys = [[coeff.value for coeff in poly.coeffs] for poly in polys]
-        all_shares = vandermonde_batch_evaluate(
+        all_values = vandermonde_batch_evaluate(
             list(range(1, n + 1)), polys, self.field.modulus
         )
+
         for i in range(n):
-            shares = [self.field(s[i]) for s in all_shares]
-            # with open(f'{file_name_prefix}_{n}_{t}_{i}.share', 'w') as f:
-            with open("%s_%d_%d-%d.share" % (file_name_prefix, n, t, i), "w") as f:
-                self._write_shares_to_file(f, t, i, shares)
+            values = [v[i] for v in all_values]
+            file_name = self.build_filename(n, t, i, prefix=prefix)
+            self._write_preprocessing_file(file_name, t, i, values, append=append)
 
-    def generate_triples(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = []
-        for _ in range(k):
-            a = self.field.random()
-            b = self.field.random()
-            c = a * b
-            polys.append(self.poly.random(t, a))
-            polys.append(self.poly.random(t, b))
-            polys.append(self.poly.random(t, c))
-        self._write_polys(PreProcessingConstants.TRIPLES_FILE_NAME_PREFIX, n, t, polys)
+            key = (i, n, t)
+            if append:
+                self.cache[key] = chain(self.cache[key], values)
+                self.count[key] += len(values)
+            else:
+                self.cache[key] = chain(values)
+                self.count[key] = len(values)
 
-    def generate_cubes(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = []
-        for _ in range(k):
-            a1 = self.field.random()
-            a2 = a1 * a1
-            a3 = a1 * a2
-            polys.append(self.poly.random(t, a1))
-            polys.append(self.poly.random(t, a2))
-            polys.append(self.poly.random(t, a3))
-        self._write_polys(PreProcessingConstants.CUBES_FILE_NAME_PREFIX, n, t, polys)
-
-    def generate_zeros(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = [self.poly.random(t, 0) for _ in range(k)]
-        self._write_polys(PreProcessingConstants.ZEROS_FILE_NAME_PREFIX, n, t, polys)
-
-    def generate_rands(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = [self.poly.random(t) for _ in range(k)]
-        self._write_polys(PreProcessingConstants.RANDS_FILE_NAME_PREFIX, n, t, polys)
-
-    def generate_bits(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = [self.poly.random(t, randint(0, 1)) for _ in range(k)]
-        self._write_polys(PreProcessingConstants.BITS_FILE_NAME_PREFIX, n, t, polys)
-
-    def generate_one_minus_one_rands(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = [self.poly.random(t, randint(0, 1) * 2 - 1) for _ in range(k)]
-        self._write_polys(
-            PreProcessingConstants.ONE_MINUS_ONE_FILE_NAME_PREFIX, n, t, polys
-        )
-
-    def generate_powers(self, k, n, t, z):
-        self._create_sharedata_dir_if_not_exists()
-        b = self.field.random().value
-
-        # Since we need all powers, multiplication
-        # is faster than using the pow() function.
-        powers = [None] * k
-        powers[0] = b
-        for i in range(1, k):
-            powers[i] = powers[i - 1] * b
-        for i in range(z):
-            polys = [self.poly.random(t, power) for power in powers]
-            self._write_polys(
-                f"{PreProcessingConstants.POWERS_FILE_NAME_PREFIX}_{i}", n, t, polys
-            )
-
-    def generate_double_shares(self, k, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        polys = []
-        for _ in range(k):
-            r = self.field.random()
-            polys.append(self.poly.random(t, r))
-            polys.append(self.poly.random(2 * t, r))
-        self._write_polys(
-            PreProcessingConstants.DOUBLE_SHARES_FILE_NAME_PREFIX, n, t, polys
-        )
-
-    def generate_share(self, x, n, t):
-        self._create_sharedata_dir_if_not_exists()
-        sid = uuid4().hex
-        polys = [self.poly.random(t, x)]
-        self._write_polys(
-            f"{PreProcessingConstants.SHARES_FILE_NAME_PREFIX}_{sid}", n, t, polys
-        )
-        return sid
-
-    def generate_share_bits(self, k, n, t):
-        """ Generates random shares, alongside their bitwise sharings.
+    def generate_values(self, k, n, t, *args, append=False, **kwargs):
+        """ Given some n, t, generate k values and write them to disk.
+        If append is true, this will add on to existing preprocessing. Otherwise,
+        this will overwrite existing preprocessing.
 
         args:
-            k (int): number of shares to generate
-            n (int): number of parties to generate shares for
-            t (int): degree of polynomial to use when generating shares
+            k: number of values to generate
+            n: number of nodes to generate for
+            t: number of faults that should be tolerated in generation
+            append: set to true if this should append, or false to overwrite.
         """
-        self._create_sharedata_dir_if_not_exists()
+        polys = self._generate_polys(k, n, t, *args, **kwargs)
+        self._write_polys(n, t, polys, append=append)
+
+    @property
+    @staticmethod
+    @abstractmethod
+    def preprocessing_name():
+        """ String representation of the type of preprocessing done by this mixin
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _preprocessing_stride(self):
+        """ Mixins should override this to return the number of values required from the
+        preprocessing file in order to fetch one preprocessing element.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _generate_polys(self, k, n, t):
+        """ Private helper method to generate polynomials for use in preprocessing.
+
+        args:
+            k: number of elements to generate
+            n: number of nodes to generate for
+            t: number of faults that should be tolerated by preprocessing
+
+        outputs: A list of polynomials corresponding to share values
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _get_value(self, context, key, *args, **kwargs):
+        """ Private helper method to retrieve a value from the cache for
+        this mixin.
+
+        args:
+            context: MPC context to retrieve the value for
+            key: tuple of (n, t, i) used to index the cache
+
+        outputs:
+            Preprocessing value for this mixin
+        """
+        raise NotImplementedError
+
+
+class ShareBitsPreProcessing(PreProcessingMixin):
+    preprocessing_name = PreProcessingConstants.SHARE_BITS.value
+
+    @property
+    def _preprocessing_stride(self):
+        return self.field.modulus.bit_length() + 1
+
+    def _generate_polys(self, k, n, t):
+        bit_length = self.field.modulus.bit_length()
         polys = []
         for _ in range(k):
             r = self.field.random()
             r_bits = [
                 self.field(b)
-                for b in map(
-                    int, reversed(f"{{0:0{self._bit_length}b}}".format(r.value))
-                )
+                for b in map(int, reversed(f"{{0:0{bit_length}b}}".format(r.value)))
             ]
 
             polys.append(self.poly.random(t, r))
-            for b in r_bits:
-                polys.append(self.poly.random(t, b))
+            polys += [self.poly.random(t, b) for b in r_bits]
 
-        self._write_polys(
-            PreProcessingConstants.SHARE_BITS_FILE_NAME_PREFIX, n, t, polys
+        return polys
+
+    def _get_value(self, context, key):
+        bit_length = self.field.modulus.bit_length()
+        assert self.count[key] >= 1
+
+        share = context.Share(next(self.cache[key]))
+        bits = [context.Share(next(self.cache[key])) for _ in range(bit_length)]
+        return (share, bits), self._preprocessing_stride
+
+
+class DoubleSharingPreProcessing(PreProcessingMixin):
+    preprocessing_name = PreProcessingConstants.DOUBLE_SHARES.value
+    _preprocessing_stride = 2
+
+    def _generate_polys(self, k, n, t):
+        polys = []
+        for _ in range(k):
+            r = self.field.random()
+            polys.append(self.poly.random(t, r))
+            polys.append(self.poly.random(2 * t, r))
+
+        return polys
+
+    def _get_value(self, context, key):
+        assert self.count[key] >= 2
+        r_t = context.Share(next(self.cache[key]))
+        r_2t = context.Share(next(self.cache[key]), 2 * context.t)
+        return (r_t, r_2t), self._preprocessing_stride
+
+
+class PowersPreProcessing(PreProcessingMixin):
+    preprocessing_name = PreProcessingConstants.POWERS.value
+    _preprocessing_stride = 1
+
+    def generate_values(self, k, n, t, z, append=False):
+        polys_arr = self._generate_polys(k, n, t, z)
+        for i, polys in enumerate(polys_arr):
+            self._write_polys(
+                n, t, polys, append=False, prefix=f"{self.file_prefix}_{i}"
+            )
+
+    def _generate_polys(self, k, n, t, z):
+        b = self.field.random().value
+        powers = [b]
+        for _ in range(1, k):
+            powers.append(powers[-1] * b)
+
+        return [[self.poly.random(t, power) for power in powers] for _ in range(z)]
+
+    def _get_value(self, context, key, pid):
+        file_name = (
+            f"{self.file_prefix}_{pid}_{context.N}_{context.t}-{context.myid}" f".share"
         )
+        return list(map(context.Share, self._read_preprocessing_file(file_name))), 0
+
+    def _refresh_cache(self):
+        pass
+
+
+class SharePreProcessing(PreProcessingMixin):
+    preprocessing_name = PreProcessingConstants.SHARES.value
+    _preprocessing_stride = 1
+
+    def generate_values(self, k, n, t, x, append=False):
+        sid = uuid4().hex
+        polys = self._generate_polys(x, n, t)
+        self._write_polys(n, t, polys, prefix=f"{self.file_prefix}_{sid}")
+        return sid
+
+    def _generate_polys(self, x, n, t):
+        return [self.poly.random(t, x)]
+
+    def _get_value(self, context, key, sid, t=None):
+        if t is None:
+            t = context.t
+        file_name = self.build_filename(
+            context.N, t, context.myid, prefix=f"{self.file_prefix}_{sid}"
+        )
+        values = self._read_preprocessing_file(file_name)
+        return context.Share(values[0], t), 0
+
+    def _refresh_cache(self):
+        pass
+
+
+class RandomPreProcessing(PreProcessingMixin):
+    preprocessing_name = PreProcessingConstants.RANDS.value
+    _preprocessing_stride = 1
+
+    def _generate_polys(self, k, n, t):
+        return [self.poly.random(t) for _ in range(k)]
+
+    def _get_value(self, context, key, t=None):
+        t = t if t is not None else context.t
+        assert self.count[key] >= 1
+        return context.Share(next(self.cache[key]), t), 1
+
+
+class SimplePreProcessing(PreProcessingMixin):
+    """ Subclass of PreProcessingMixin to be used in the trivial case
+    where the only thing required to get a value is to read _preprocessing_stride
+    values, turn them in to shares, and return a tuple of them.
+
+    Subclasses of this class must only overwrite _generate_polys
+    """
+
+    def _get_value(self, context, key):
+        assert self.count[key] >= self._preprocessing_stride, (
+            f"Expected "
+            f"{self._preprocessing_stride} elements of {self.preprocessing_name}, "
+            f"but found only {self.count[key]}"
+        )
+
+        values = tuple(
+            context.Share(next(self.cache[key]))
+            for _ in range(self._preprocessing_stride)
+        )
+
+        if len(values) == 1:
+            values = values[0]
+
+        return values, self._preprocessing_stride
+
+
+class CubePreProcessing(SimplePreProcessing):
+    preprocessing_name = PreProcessingConstants.CUBES.value
+    _preprocessing_stride = 3
+
+    def _generate_polys(self, k, n, t):
+        polys = []
+        for _ in range(k):
+            a = self.field.random()
+            b = a * a
+            c = a * b
+            polys += [self.poly.random(t, v) for v in (a, b, c)]
+
+        return polys
+
+
+class TriplePreProcessing(SimplePreProcessing):
+    preprocessing_name = PreProcessingConstants.TRIPLES.value
+    _preprocessing_stride = 3
+
+    def _generate_polys(self, k, n, t):
+        polys = []
+        for _ in range(k):
+            a = self.field.random()
+            b = self.field.random()
+            c = a * b
+            polys += [self.poly.random(t, v) for v in (a, b, c)]
+
+        return polys
+
+
+class ZeroPreProcessing(SimplePreProcessing):
+    preprocessing_name = PreProcessingConstants.ZEROS.value
+    _preprocessing_stride = 1
+
+    def _generate_polys(self, k, n, t):
+        return [self.poly.random(t, 0) for _ in range(k)]
+
+
+class BitPreProcessing(SimplePreProcessing):
+    preprocessing_name = PreProcessingConstants.BITS.value
+    _preprocessing_stride = 1
+
+    def _generate_polys(self, k, n, t):
+        return [self.poly.random(t, randint(0, 1)) for _ in range(k)]
+
+
+class SignedBitPreProcessing(SimplePreProcessing):
+    preprocessing_name = PreProcessingConstants.ONE_MINUS_ONE.value
+    _preprocessing_stride = 1
+
+    def _generate_polys(self, k, n, t):
+        return [self.poly.random(t, randint(0, 1) * 2 - 1) for _ in range(k)]
+
+
+class PreProcessedElements:
+    """ Main accessor of preprocessing
+    This class is a singleton, that only has one object per field being
+    preprocessed for.
+    """
+
+    DEFAULT_DIRECTORY = PreProcessingConstants.SHARED_DATA_DIR.value
+    DEFAULT_FIELD = GF(Subgroup.BLS12_381)
+
+    _cached_elements = {}
+
+    def __new__(cls, append=True, data_directory=None, field=None):
+        """ Called when a new PreProcessedElements is created.
+        This creates a multiton based on the directory used in preprocessing
+        """
+        if data_directory is None:
+            data_directory = cls.DEFAULT_DIRECTORY
+
+        return PreProcessedElements._cached_elements.setdefault(
+            data_directory, super(PreProcessedElements, cls).__new__(cls)
+        )
+
+    def __init__(self, append=True, data_directory=None, field=None):
+        """
+        args:
+            field: GF to use when generating preprocessing
+            append: whether or not we should append to existing preprocessing when
+                generating, or if we should overwrite existing preprocessing.
+            data_dir_name: directory name to write preprocessing to.
+        """
+        if data_directory is None:
+            data_directory = PreProcessedElements.DEFAULT_DIRECTORY
+
+        if field is None:
+            field = PreProcessedElements.DEFAULT_FIELD
+
+        self.field = field
+        self.poly = polynomials_over(field)
+
+        self.data_directory = data_directory
+        self._init_data_dir()
+
+        self._ready_file = (
+            f"{self.data_directory}" f"{PreProcessingConstants.READY_FILE_NAME}"
+        )
+
+        self._append = append
+
+        # Instantiate preprocessing mixins
+        self._triples = TriplePreProcessing(self.field, self.poly, self.data_directory)
+        self._cubes = CubePreProcessing(self.field, self.poly, self.data_directory)
+        self._zeros = ZeroPreProcessing(self.field, self.poly, self.data_directory)
+        self._rands = RandomPreProcessing(self.field, self.poly, self.data_directory)
+        self._bits = BitPreProcessing(self.field, self.poly, self.data_directory)
+        self._powers = PowersPreProcessing(self.field, self.poly, self.data_directory)
+        self._shares = SharePreProcessing(self.field, self.poly, self.data_directory)
+        self._one_minus_ones = SignedBitPreProcessing(
+            self.field, self.poly, self.data_directory
+        )
+        self._double_shares = DoubleSharingPreProcessing(
+            self.field, self.poly, self.data_directory
+        )
+        self._share_bits = ShareBitsPreProcessing(
+            self.field, self.poly, self.data_directory
+        )
+
+    @classmethod
+    def reset_cache(cls):
+        """ Reset the class-wide cache of PreProcessedElements objects
+        """
+        cls._cached_elements = {}
+
+    def _init_data_dir(self):
+        """ Ensures that the data directory exists.
+        """
+        makedirs(self.data_directory, exist_ok=True)
+
+    def clear_preprocessing(self):
+        """ Delete all things from the preprocessing folder
+        """
+        rmtree(
+            self.data_directory,
+            onerror=lambda f, p, e: logging.debug(
+                f"Error deleting data directory: {e}"
+            ),
+        )
+
+        self._init_data_dir()
+
+    async def wait_for_preprocessing(self, timeout=1):
+        """ Block until the ready file is created
+        """
+        while not os.path.exists(self._ready_file):
+            logging.info(f"waiting for preprocessing {self._ready_file}")
+            await asyncio.sleep(timeout)
+
+    def preprocessing_done(self):
+        """ Create a ready file. This unblocks any calls to wait_for_preprocessing
+        """
+        os.mknod(self._ready_file)
+
+    def _generate(self, mixin, k, n, t, *args, **kwargs):
+        """ Generate k elements with given n, t values for the given kind of
+        preprocessing.
+        If we already have preprocessing for that kind, we only generate enough
+        such that we have k elements cached.
+        """
+        if self._append:
+            k -= mixin.min_count(n, t)
+
+        if k > 0:
+            return mixin.generate_values(k, n, t, *args, append=self._append, **kwargs)
+
+    def generate_triples(self, k, n, t):
+        return self._generate(self._triples, k, n, t)
+
+    def generate_cubes(self, k, n, t):
+        return self._generate(self._cubes, k, n, t)
+
+    def generate_zeros(self, k, n, t):
+        return self._generate(self._zeros, k, n, t)
+
+    def generate_rands(self, k, n, t):
+        return self._generate(self._rands, k, n, t)
+
+    def generate_bits(self, k, n, t):
+        return self._generate(self._bits, k, n, t)
+
+    def generate_one_minus_ones(self, k, n, t):
+        return self._generate(self._one_minus_ones, k, n, t)
+
+    def generate_double_shares(self, k, n, t):
+        return self._generate(self._double_shares, k, n, t)
+
+    def generate_share_bits(self, k, n, t):
+        return self._generate(self._share_bits, k, n, t)
+
+    def generate_powers(self, k, n, t, z):
+        return self._generate(self._powers, k, n, t, z)
+
+    def generate_share(self, n, t, *args, **kwargs):
+        return self._generate(self._shares, 1, n, t, *args, **kwargs)
+
+    ## Preprocessing retrieval methods:
+
+    def get_triples(self, context):
+        return self._triples.get_value(context)
+
+    def get_cubes(self, context):
+        return self._cubes.get_value(context)
+
+    def get_zero(self, context):
+        return self._zeros.get_value(context)
+
+    def get_rand(self, context, t=None):
+        return self._rands.get_value(context, t)
+
+    def get_bit(self, context):
+        return self._bits.get_value(context)
+
+    def get_powers(self, context, z):
+        return self._powers.get_value(context, z)
+
+    def get_share(self, context, sid, t=None):
+        return self._shares.get_value(context, sid, t)
+
+    def get_one_minus_ones(self, context):
+        return self._one_minus_ones.get_value(context)
+
+    def get_double_shares(self, context):
+        return self._double_shares.get_value(context)
+
+    def get_share_bits(self, context):
+        return self._share_bits.get_value(context)

--- a/honeybadgermpc/progs/jubjub.py
+++ b/honeybadgermpc/progs/jubjub.py
@@ -52,9 +52,6 @@ class SharedPoint(object):
 
         return res
 
-        # x, y = await asyncio.gather(self.xs.open(), self.ys.open())
-        # return Point(x, y, self.curve)
-
     def equals(self, other):
         """Returns a future that evaluates to the result of the equality check
         """

--- a/honeybadgermpc/progs/mimc.py
+++ b/honeybadgermpc/progs/mimc.py
@@ -1,5 +1,5 @@
 from math import log, ceil
-from honeybadgermpc.mpc import PreProcessedElements, Subgroup
+from honeybadgermpc.elliptic_curve import Subgroup
 
 # ROUND: iteration time of MiMC encryption function,
 # In BLS12_381, r = ceil(log(p, 3)) = 161
@@ -20,11 +20,9 @@ async def mimc_mpc(context, x, k):
     where either x or k can be secret share, the other is an element of F_p
     See: https://eprint.iacr.org/2016/542.pdf
     """
-    pp_elements = PreProcessedElements()
-
     # def cubing_share(): [x] -> [x^3]
     async def cubing_share(x):
-        r1, r2, r3 = pp_elements.get_cube(context)
+        r1, r2, r3 = context.preproc.get_cubes(context)
         y = await (x - r1).open()
         # [x^3] = 3y[r^2] + 3y^2[r] + y^3 + [r^3]
         x3 = 3 * y * r2 + 3 * (y ** 2) * r1 + y ** 3 + r3
@@ -33,7 +31,7 @@ async def mimc_mpc(context, x, k):
     # iterating the round function ROUND times
     inp = x
     for ctr in range(ROUND):
-        inp = await cubing_share((k + context.field(ctr)) + inp)
+        inp = await cubing_share(k + (context.field(ctr) + inp))
 
     return inp + k
 
@@ -43,26 +41,17 @@ async def mimc_mpc_batch(context, xs, k):
     MiMC block cipher encryption encrypts blocks of message xs with secret key k,
     where xs are a list of shared secrets, k is an element of F_p
     """
-    pp_elements = PreProcessedElements()
-
     # def cubing_share_array(): [x1,..., xK] -> [x1^3,..., xK^3]
     async def cubing_share_array(xs):
-        rs, rs_sq, rs_cube = [], [], []
-        x3s = []
-
-        for x in xs:
-            r1, r2, r3 = pp_elements.get_cube(context)
-            y = await (x - r1).open()
-            rs.append(r1)
-            rs_sq.append(r2)
-            rs_cube.append(r3)
+        rs, rs_sq, rs_cube = zip(
+            *[context.preproc.get_cubes(context) for _ in range(len(xs))]
+        )
 
         ys = await (context.ShareArray(xs) - context.ShareArray(rs)).open()
-        for i, y in enumerate(ys):
-            # [x^3] = 3y[r^2] + 3y^2[r] + y^3 + [r^3]
-            x3s.append(3 * y * rs_sq[i] + 3 * (y ** 2) * rs[i] + y ** 3 + rs_cube[i])
-
-        return x3s
+        return [
+            3 * y * rs_sq[i] + 3 * (y ** 2) * rs[i] + y ** 3 + rs_cube[i]
+            for i, y in enumerate(ys)
+        ]
 
     # iterating the round function ROUND times
     inp_array = xs

--- a/honeybadgermpc/progs/mimc_jubjub_pkc.py
+++ b/honeybadgermpc/progs/mimc_jubjub_pkc.py
@@ -1,6 +1,4 @@
 import asyncio
-from random import randint
-from honeybadgermpc.mpc import PreProcessedElements
 from honeybadgermpc.elliptic_curve import Point, Jubjub
 from honeybadgermpc.progs.jubjub import share_mul
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
@@ -18,10 +16,8 @@ async def key_generation(context, key_length=32):
     as the private key (priv_key),
     then calcultes X = ([x]G).open as the public key (pub_key)
     """
-    pp_elements = PreProcessedElements()
-
     # Generate the private key
-    priv_key = [pp_elements.get_bit(context) for _ in range(key_length)]
+    priv_key = [context.preproc.get_bit(context) for _ in range(key_length)]
 
     # Compute [X] = [x]G, then open it as public key
     pub_key_share = await share_mul(context, priv_key, GP)
@@ -44,7 +40,7 @@ def mimc_encrypt(pub_key, ms, seed=None):
     """
 
     # Randomly generated variable hold only by the dealer
-    a = randint(0, Jubjub.Field.modulus) if seed is None else seed
+    a = Jubjub.Field.random() if seed is None else seed
     # Auxiliary variable needed for decryption
     a_ = a * GP
 
@@ -76,6 +72,7 @@ async def mimc_decrypt(context, priv_key, ciphertext):
     mpcs = await asyncio.gather(
         *[mimc_mpc(context, context.field(i), k_share) for i in range(len(cs))]
     )
+
     decrypted = [c - m for (c, m) in zip(cs, mpcs)]
 
     return decrypted

--- a/honeybadgermpc/progs/mimc_symmetric.py
+++ b/honeybadgermpc/progs/mimc_symmetric.py
@@ -1,9 +1,8 @@
 import asyncio
 from honeybadgermpc.field import GF
-from honeybadgermpc.mpc import PreProcessedElements, Subgroup
+from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
 
-pp_elements = PreProcessedElements()
 field = GF(Subgroup.BLS12_381)
 
 

--- a/honeybadgermpc/progs/mixins/base.py
+++ b/honeybadgermpc/progs/mixins/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.utils.typecheck import TypeCheck
 
 
@@ -7,8 +6,6 @@ class MixinBase(ABC):
     """Abstract base class for all Mixin objects
     These will work like drag-and-drop functors to load in some mpc applications
     """
-
-    pp_elements = PreProcessedElements()
 
     @abstractmethod
     def __call__(self, *args, **kwargs):

--- a/honeybadgermpc/progs/mixins/share_arithmetic.py
+++ b/honeybadgermpc/progs/mixins/share_arithmetic.py
@@ -1,4 +1,4 @@
-from honeybadgermpc.progs.mixins.base import MixinBase, AsyncMixin
+from honeybadgermpc.progs.mixins.base import AsyncMixin
 from honeybadgermpc.progs.mixins.constants import MixinConstants
 from honeybadgermpc.utils.typecheck import TypeCheck
 from honeybadgermpc.progs.mixins.dataflow import Share, ShareArray
@@ -15,7 +15,7 @@ class BeaverMultiply(AsyncMixin):
     @staticmethod
     @TypeCheck()
     async def _prog(context: Mpc, x: Share, y: Share):
-        a, b, ab = MixinBase.pp_elements.get_triple(context)
+        a, b, ab = context.preproc.get_triples(context)
 
         d, e = await gather(*[(x - a).open(), (y - b).open()])
         xy = d * e + d * b + e * a + ab
@@ -34,7 +34,7 @@ class BeaverMultiplyArrays(AsyncMixin):
 
         a, b, ab = [], [], []
         for _ in range(len(j)):
-            p, q, pq = MixinBase.pp_elements.get_triple(context)
+            p, q, pq = context.preproc.get_triples(context)
             a.append(p)
             b.append(q)
             ab.append(pq)
@@ -56,7 +56,7 @@ class DoubleSharingMultiply(AsyncMixin):
     async def reduce_degree_share(context: Mpc, x_2t: Share):
         assert x_2t.t == context.t * 2
 
-        r_t, r_2t = MixinBase.pp_elements.get_double_share(context)
+        r_t, r_2t = context.preproc.get_double_shares(context)
         diff = await (x_2t - r_2t).open()
 
         return r_t + diff
@@ -81,7 +81,7 @@ class DoubleSharingMultiplyArrays(AsyncMixin):
 
         r_t, r_2t = [], []
         for _ in range(len(x_2t)):
-            r_t_, r_2t_ = MixinBase.pp_elements.get_double_share(context)
+            r_t_, r_2t_ = context.preproc.get_double_shares(context)
             r_t.append(r_t_)
             r_2t.append(r_2t_)
 
@@ -112,7 +112,7 @@ class InvertShare(AsyncMixin):
     @staticmethod
     @TypeCheck()
     async def _prog(context: Mpc, x: Share):
-        r = MixinBase.pp_elements.get_rand(context)
+        r = context.preproc.get_rand(context)
         sig = await (x * r).open()
 
         return r * (1 / sig)
@@ -127,7 +127,7 @@ class InvertShareArray(AsyncMixin):
     @TypeCheck()
     async def _prog(context: Mpc, xs: ShareArray):
         rs = context.ShareArray(
-            [MixinBase.pp_elements.get_rand(context) for _ in range(len(xs))]
+            [context.preproc.get_rand(context) for _ in range(len(xs))]
         )
 
         sigs = await (await (xs * rs)).open()
@@ -181,6 +181,40 @@ class Equality(AsyncMixin):
         elif b == a.modulus - 1:
             return -1
         return 0
+
+    @staticmethod
+    @TypeCheck()
+    async def _gen_test_bit(context: Mpc, diff: Share):
+        # # b \in {0, 1}
+        b = context.preproc.get_bit(context)
+
+        # # _b \in {5, 1}, for p = 1 mod 8, s.t. (5/p) = -1
+        # # so _b = -4 * b + 5
+        _b = (-4 * b) + context.Share(5)
+
+        _r = context.preproc.get_rand(context)
+        _rp = context.preproc.get_rand(context)
+
+        # c = a * r + b * rp * rp
+        # If b_i == 1, c_i is guaranteed to be a square modulo p if a is zero
+        # and with probability 1/2 otherwise (except if rp == 0).
+        # If b_i == -1 it will be non-square.
+        c = await ((diff * _r) + (_b * _rp * _rp)).open()
+
+        return c, _b
+
+    @staticmethod
+    @TypeCheck
+    async def gen_test_bit(context: Mpc, diff: Share):
+        cj, bj = await Equality._gen_test_bit(context, diff)
+        while cj == 0:
+            cj, bj = await Equality._gen_test_bit(context, diff)
+
+        legendre = Equality.legendre_mod_p(cj)
+        if legendre == 0:
+            return Equality.gen_test_bit(context, diff)
+
+        return (legendre / context.field(2)) * (bj + context.Share(legendre))
 
     @staticmethod
     @TypeCheck()

--- a/honeybadgermpc/progs/mixins/share_comparison.py
+++ b/honeybadgermpc/progs/mixins/share_comparison.py
@@ -30,14 +30,14 @@ class Equality(AsyncMixin):
     @TypeCheck()
     async def _gen_test_bit(context: Mpc, diff: Share):
         # # b \in {0, 1}
-        b = Equality.pp_elements.get_bit(context)
+        b = context.preproc.get_bit(context)
 
         # # _b \in {5, 1}, for p = 1 mod 8, s.t. (5/p) = -1
         # # so _b = -4 * b + 5
         _b = (-4 * b) + context.Share(5)
 
-        _r = Equality.pp_elements.get_rand(context)
-        _rp = Equality.pp_elements.get_rand(context)
+        _r = context.preproc.get_rand(context)
+        _rp = context.preproc.get_rand(context)
 
         # c = a * r + b * rp * rp
         # If b_i == 1, c_i is guaranteed to be a square modulo p if a is zero
@@ -121,7 +121,7 @@ class LessThan(AsyncMixin):
         """
         z = a_share - b_share
 
-        r_b, r_bits = LessThan.pp_elements.get_share_bits(context)
+        r_b, r_bits = context.preproc.get_share_bits(context)
 
         # [c] = 2[z] + [r]_B = 2([a]-[b]) + [r]_B
         c = await (2 * z + r_b).open()
@@ -170,7 +170,7 @@ class LessThan(AsyncMixin):
         """
         bit_length = context.field.modulus.bit_length()
 
-        s_b, s_bits = LessThan.pp_elements.get_share_bits(context)
+        s_b, s_bits = context.preproc.get_share_bits(context)
         d_ = s_b + x
         d = await d_.open()
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ VERSION = None
 REQUIRED = ["gmpy2", "zfec", "pycrypto", "cffi", "psutil", "pyzmq"]
 
 TESTS_REQUIRES = [
-    "black",
     "flake8",
     "pep8-naming",
     "pytest",

--- a/tests/progs/mixins/test_share_comparison.py
+++ b/tests/progs/mixins/test_share_comparison.py
@@ -1,5 +1,5 @@
-import logging
 from pytest import mark
+from asyncio import gather
 from random import randint
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
@@ -12,6 +12,7 @@ from honeybadgermpc.progs.mixins.share_arithmetic import (
     DivideShareArrays,
 )
 from honeybadgermpc.progs.mixins.share_comparison import Equality, LessThan
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 STANDARD_ARITHMETIC_MIXINS = [
     BeaverMultiply(),
@@ -25,8 +26,7 @@ STANDARD_ARITHMETIC_MIXINS = [
 ]
 
 PREPROCESSING = ["rands", "triples", "zeros", "cubes", "bits"]
-n, t = 4, 1
-k = 10000
+n, t = 3, 1
 
 FIELD = GF(Subgroup.BLS12_381)
 
@@ -39,8 +39,9 @@ range_pairs = [(x, y) for x, y in zip(ranges[:-1], ranges[1:])]
 
 @mark.asyncio
 @mark.parametrize("begin,end", range_pairs)
-async def test_less_than(begin, end, test_preprocessing, test_runner):
-    test_preprocessing.generate("share_bits", n, t, k=50)
+async def test_less_than(begin, end, test_runner):
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_share_bits(50, n, t)
     a_values = [randint(begin, end) for _ in range(3)]
     b_values = [a_values[0] - DIFF, a_values[1], a_values[2] + DIFF]
 
@@ -48,27 +49,28 @@ async def test_less_than(begin, end, test_preprocessing, test_runner):
         a_shares = [context.Share(v) for v in a_values]
         b_shares = [context.Share(v) for v in b_values]
 
-        for (a_, b_, a, b) in zip(a_shares, b_shares, a_values, b_values):
-            if context.myid == 0:
-                logging.info(f"a: {a}; b: {b}")
-            res = bool(await (a_ < b_).open())
-            assert res == (a < b)
+        results = await gather(
+            *[(a_ < b_).open() for a_, b_ in zip(a_shares, b_shares)]
+        )
 
-    await test_runner(_prog, n, t, PREPROCESSING, k, STANDARD_ARITHMETIC_MIXINS)
+        for (res, a, b) in zip(results, a_values, b_values):
+            assert bool(res) == (a < b)
+
+    await test_runner(_prog, n, t, PREPROCESSING, 2500, STANDARD_ARITHMETIC_MIXINS)
 
 
 @mark.asyncio
-async def test_equality(test_preprocessing, test_runner):
+async def test_equality(test_runner):
     equality = Equality()
 
     async def _prog(context):
-        share0 = test_preprocessing.elements.get_zero(context)
-        share1 = test_preprocessing.elements.get_rand(context)
+        share0 = context.preproc.get_zero(context)
+        share1 = context.preproc.get_rand(context)
         share1_ = share0 + share1
-        share2 = test_preprocessing.elements.get_rand(context)
+        share2 = context.preproc.get_rand(context)
 
         assert await (await equality(context, share1, share1_)).open()
         assert await (share1 == share1_).open()
         assert not await (share1 == share2).open()
 
-    await test_runner(_prog, n, t, PREPROCESSING, k, STANDARD_ARITHMETIC_MIXINS)
+    await test_runner(_prog, n, t, PREPROCESSING, 1000, STANDARD_ARITHMETIC_MIXINS)

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -48,11 +48,11 @@ STANDARD_ARITHMETIC_MIXINS = [
 
 STANDARD_PREPROCESSING = ["rands", "triples", "bits"]
 
-n, t = 4, 1
+n, t = 3, 1
 
 
 async def run_test_program(
-    prog, test_runner, n=n, t=t, k=10000, mixins=STANDARD_ARITHMETIC_MIXINS
+    prog, test_runner, n=n, t=t, k=1000, mixins=STANDARD_ARITHMETIC_MIXINS
 ):
 
     return await test_runner(prog, n, t, STANDARD_PREPROCESSING, k, mixins)
@@ -90,7 +90,7 @@ def test_basic_point_functionality():
 
 
 @mark.asyncio
-async def test_shared_point_equals(test_preprocessing, test_runner):
+async def test_shared_point_equals(test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[0])
         p2 = SharedPoint.from_point(context, TEST_POINTS[1])
@@ -117,7 +117,7 @@ async def test_shared_point_equals(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_creation_from_point(test_preprocessing, test_runner):
+async def test_shared_point_creation_from_point(test_runner):
     async def _prog(context):
         p1 = Point(0, 1)
         p1s = SharedPoint.from_point(context, p1)
@@ -127,7 +127,7 @@ async def test_shared_point_creation_from_point(test_preprocessing, test_runner)
 
 
 @mark.asyncio
-async def test_shared_point_double(test_preprocessing, test_runner):
+async def test_shared_point_double(test_runner):
     async def _prog(context):
         shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
         actual_doubled = [
@@ -145,7 +145,7 @@ async def test_shared_point_double(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_neg(test_preprocessing, test_runner):
+async def test_shared_point_neg(test_runner):
     async def _prog(context):
         shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
         actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
@@ -161,7 +161,7 @@ async def test_shared_point_neg(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_add(test_preprocessing, test_runner):
+async def test_shared_point_add(test_runner):
     async def _prog(context):
         ideal = SharedIdeal(TEST_CURVE)
 
@@ -183,7 +183,7 @@ async def test_shared_point_add(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_sub(test_preprocessing, test_runner):
+async def test_shared_point_sub(test_runner):
     async def _prog(context):
         shared_points = [SharedPoint.from_point(context, p) for p in TEST_POINTS]
         actual_negated = [SharedPoint.from_point(context, -p) for p in TEST_POINTS]
@@ -202,7 +202,7 @@ async def test_shared_point_sub(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_mul(test_preprocessing, test_runner):
+async def test_shared_point_mul(test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[1])
         p1_double = p1.double()
@@ -218,7 +218,7 @@ async def test_shared_point_mul(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
+async def test_shared_point_montgomery_mul(test_runner):
     async def _prog(context):
         p1 = SharedPoint.from_point(context, TEST_POINTS[1])
         p1_double = p1.double()
@@ -232,16 +232,14 @@ async def test_shared_point_montgomery_mul(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_share_mul(test_preprocessing, test_runner):
-    bit_length = 80  # Short key for testing
+async def test_share_mul(test_runner):
+    bit_length = 40  # Short key for testing
 
     async def _prog(context):
         p = TEST_POINTS[1]
 
         multiplier_ = Jubjub.Field(0)
-        m_bits = [
-            test_preprocessing.elements.get_bit(context) for i in range(bit_length)
-        ]
+        m_bits = [context.preproc.get_bit(context) for i in range(bit_length)]
 
         for idx, m in enumerate(m_bits):
             multiplier_ += (2 ** idx) * m

--- a/tests/progs/test_mimc.py
+++ b/tests/progs/test_mimc.py
@@ -7,14 +7,14 @@ from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ["rands", "triples", "zeros", "cubes"]
-n, t = 3, 1
-k = 10000
+n, t = 4, 1
+k = 3500
 
 
 @mark.asyncio
-async def test_mimc(test_preprocessing, test_runner):
+async def test_mimc(test_runner):
     async def _prog(context):
-        x = test_preprocessing.elements.get_zero(context)
+        x = context.preproc.get_zero(context)
         field = GF(Subgroup.BLS12_381)
         key = field(15)
 
@@ -33,12 +33,12 @@ async def test_mimc(test_preprocessing, test_runner):
 
 
 @mark.asyncio
-async def test_mimc_mpc_batch(test_preprocessing, test_runner):
+async def test_mimc_mpc_batch(test_runner):
     field = GF(Subgroup.BLS12_381)
     key = field(randint(0, field.modulus))
 
     async def _prog(context):
-        xs = [test_preprocessing.elements.get_rand(context) for _ in range(20)]
+        xs = [context.preproc.get_rand(context) for _ in range(20)]
 
         # Compute F_MiMC_mpc, mm - mimc_mpc
         mm = await mimc_mpc_batch(context, xs, key)

--- a/tests/progs/test_mimc_jubjub_pkc.py
+++ b/tests/progs/test_mimc_jubjub_pkc.py
@@ -1,5 +1,4 @@
 from pytest import mark
-from random import randint
 import asyncio
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
@@ -30,15 +29,15 @@ STANDARD_ARITHMETIC_MIXINS = [
 
 PREPROCESSING = ["rands", "triples", "zeros", "cubes", "bits"]
 n, t = 4, 1
-k = 10000
+k = 1000
 
 
 @mark.asyncio
-async def test_mimc_jubjub_pkc(test_preprocessing, test_runner):
+async def test_mimc_jubjub_pkc(test_runner):
 
     field = GF(Subgroup.BLS12_381)
-    plaintext = [randint(0, field.modulus)]
-    seed = randint(0, field.modulus)
+    plaintext = [field.random().value]
+    seed = field.random().value
 
     async def _prog(context):
         # Key Generation

--- a/tests/progs/test_mimc_symmetric.py
+++ b/tests/progs/test_mimc_symmetric.py
@@ -1,26 +1,24 @@
 from pytest import mark
 from random import randint
 from honeybadgermpc.field import GF
-from honeybadgermpc.mpc import PreProcessedElements, Subgroup
+from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 from honeybadgermpc.progs.mimc_symmetric import mimc_encrypt, mimc_decrypt
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ["rands", "triples", "zeros", "cubes", "bits"]
-n, t = 3, 1
-k = 10000
+n, t = 4, 1
+k = 1000
 
 
 @mark.asyncio
-async def test_mimc_symmetric(test_preprocessing, test_runner):
-
-    pp_elements = PreProcessedElements()
+async def test_mimc_symmetric(test_runner):
     field = GF(Subgroup.BLS12_381)
     plaintext = [randint(0, field.modulus)]
     key_ = field(randint(0, field.modulus))
 
     async def _prog(context):
-        key = pp_elements.get_zero(context) + key_
+        key = context.preproc.get_zero(context) + key_
 
         cipher = mimc_encrypt(key_, plaintext)
         decrypted_value = await mimc_decrypt(context, key, cipher)

--- a/tests/progs/test_random_refinement.py
+++ b/tests/progs/test_random_refinement.py
@@ -4,13 +4,9 @@ from honeybadgermpc.progs.random_refinement import refine_randoms
 
 @mark.parametrize("n, t, k", [(4, 1, 3), (4, 1, 4), (7, 2, 5)])
 @mark.asyncio
-async def test_random_refinement(
-    n, t, k, galois_field, polynomial, test_preprocessing, test_runner
-):
+async def test_random_refinement(n, t, k, galois_field, polynomial, test_runner):
     async def _prog(context):
-        random_shares = [
-            test_preprocessing.elements.get_rand(context).v.value for i in range(k)
-        ]
+        random_shares = [context.preproc.get_rand(context).v.value for i in range(k)]
         refined_random_shares = refine_randoms(n, t, galois_field, random_shares)
         assert len(refined_random_shares) == k - t
         randoms = await context.ShareArray(refined_random_shares).open()

--- a/tests/progs/test_triple_refinement.py
+++ b/tests/progs/test_triple_refinement.py
@@ -5,12 +5,12 @@ from honeybadgermpc.progs.triple_refinement import refine_triples
 
 @mark.asyncio
 @mark.parametrize("n, t, k", [(4, 1, 3), (4, 1, 4), (7, 2, 5), (7, 2, 7)])
-async def test_triple_refinement(n, t, k, test_preprocessing, test_runner):
+async def test_triple_refinement(n, t, k, test_runner):
     async def _prog(context):
         _a, _b, _c = [], [], []
         # Every party needs its share of all the `N` triples' shares
         for _ in range(k):
-            p, q, pq = test_preprocessing.elements.get_triple(context)
+            p, q, pq = context.preproc.get_triples(context)
             _a.append(p.v.value), _b.append(q.v.value), _c.append(pq.v.value)
         p, q, pq = await refine_triples(context, _a, _b, _c)
 

--- a/tests/test_asynchromix.py
+++ b/tests/test_asynchromix.py
@@ -1,26 +1,31 @@
 from pytest import mark
+from honeybadgermpc.preprocessing import PreProcessedElements
+import apps.asynchromix.butterfly_network as butterfly
+from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
+from honeybadgermpc.progs.mixins.constants import MixinConstants
+import apps.asynchromix.powermixing as pm
+from uuid import uuid4
 
 
 @mark.asyncio
-async def test_butterfly_network(test_preprocessing):
-    import apps.asynchromix.butterfly_network as butterfly
-    from honeybadgermpc.mpc import TaskProgramRunner
-    from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
-    from honeybadgermpc.progs.mixins.constants import MixinConstants
-
+async def test_butterfly_network():
     n, t, k, delta = 3, 1, 32, -9999
-    test_preprocessing.generate("rands", n, t)
-    test_preprocessing.generate("oneminusone", n, t)
-    test_preprocessing.generate("triples", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_rands(1000, n, t)
+    pp_elements.generate_one_minus_ones(1000, n, t)
+    pp_elements.generate_triples(1500, n, t)
 
     async def verify_output(ctx, **kwargs):
         k, delta = kwargs["k"], kwargs["delta"]
-        inputs = [test_preprocessing.elements.get_rand(ctx) for _ in range(k)]
+        inputs = [ctx.preproc.get_rand(ctx) for _ in range(k)]
         sorted_input = sorted(
             await ctx.ShareArray(inputs).open(), key=lambda x: x.value
         )
 
-        share_arr = await butterfly.butterfly_network_helper(ctx, k=k, delta=delta)
+        share_arr = await butterfly.butterfly_network_helper(
+            ctx, k=k, delta=delta, inputs=inputs
+        )
         outputs = await share_arr.open()
 
         assert len(sorted_input) == len(outputs)
@@ -36,34 +41,28 @@ async def test_butterfly_network(test_preprocessing):
 
 
 @mark.asyncio
-async def test_phase1(test_preprocessing, galois_field):
-    from honeybadgermpc.mpc import TaskProgramRunner
-    from honeybadgermpc.preprocessing import PreProcessingConstants
-    import apps.asynchromix.powermixing as pm
-    from uuid import uuid4
-
+async def test_phase1(galois_field):
     field = galois_field
     n, t, k = 5, 2, 1
-    test_preprocessing.generate("powers", n, t, k, 1)
-    test_preprocessing.generate("rands", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_powers(k, n, t, 1)
+    pp_elements.generate_rands(k, n, t)
 
-    async def verify_phase1(context, **kwargs):
+    async def verify_phase1(ctx, **kwargs):
         k_ = kwargs["k"]
-        b_ = await test_preprocessing.elements.get_powers(context, 0)[0].open()
+        b_ = await ctx.preproc.get_powers(ctx, 0)[0].open()
         file_prefixes = [uuid4().hex]
-        await pm.all_secrets_phase1(context, k=k, file_prefixes=file_prefixes)
-        file_name = f"{file_prefixes[0]}-{context.myid}.input"
-        file_path = f"{PreProcessingConstants.SHARED_DATA_DIR}{file_name}"
+        await pm.all_secrets_phase1(ctx, k=k, file_prefixes=file_prefixes)
+        file_name = f"{file_prefixes[0]}-{ctx.myid}.input"
+        file_path = f"{pp_elements.data_directory}{file_name}"
         with open(file_path, "r") as f:
             assert int(f.readline()) == field.modulus
             # next line is a random share, which should open successfully
-            a_ = await context.Share(int(f.readline())).open()
+            a_ = await ctx.Share(int(f.readline())).open()
             assert int(f.readline()) == (a_ - b_).value
             assert int(f.readline()) == k_
             for i in range(1, k_ + 1):
-                assert (await context.Share(int(f.readline())).open()).value == b_ ** (
-                    i
-                )
+                assert (await ctx.Share(int(f.readline())).open()).value == b_ ** (i)
 
     program_runner = TaskProgramRunner(n, t)
     program_runner.add(verify_phase1, k=k)
@@ -72,19 +71,16 @@ async def test_phase1(test_preprocessing, galois_field):
 
 @mark.asyncio
 async def test_phase2(galois_field):
-    from honeybadgermpc.preprocessing import PreProcessingConstants
-    import apps.asynchromix.powermixing as pm
-    import uuid
 
     field = galois_field
     a = field.random()
     b = field.random()
     k = 8
-    share_id, run_id, node_id = uuid.uuid4().hex, uuid.uuid4().hex, "1"
+    share_id, run_id, node_id = uuid4().hex, uuid4().hex, "1"
 
     for j in range(1, k):
         file_name = f"{share_id}-{node_id}.input"
-        with open(f"{PreProcessingConstants.SHARED_DATA_DIR}{file_name}", "w") as f:
+        with open(f"{PreProcessedElements.DEFAULT_DIRECTORY}{file_name}", "w") as f:
             print(field.modulus, file=f)
             print(a.value, file=f)
             print((a - b).value, file=f)
@@ -95,7 +91,7 @@ async def test_phase2(galois_field):
         await pm.phase2(node_id, run_id, share_id)
 
         file_name = f"power-{run_id}_{node_id}.sums"
-        with open(f"{PreProcessingConstants.SHARED_DATA_DIR}{file_name}", "r") as f:
+        with open(f"{PreProcessedElements.DEFAULT_DIRECTORY}{file_name}", "r") as f:
             assert int(f.readline()) == field.modulus
             assert int(f.readline()) == k
             for i, p in enumerate(f.read().splitlines()[:k]):
@@ -103,14 +99,15 @@ async def test_phase2(galois_field):
 
 
 @mark.asyncio
-async def test_asynchronous_mixing(test_preprocessing):
+async def test_asynchronous_mixing():
     import asyncio
     import apps.asynchromix.powermixing as pm
     from honeybadgermpc.mpc import TaskProgramRunner
 
     n, t, k = 3, 1, 4
-    test_preprocessing.generate("powers", n, t, k, k)
-    test_preprocessing.generate("rands", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_powers(k, n, t, k)
+    pp_elements.generate_rands(1000, n, t)
 
     async def verify_output(context, **kwargs):
         result, input_shares = kwargs["result"], kwargs["input_shares"]

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -2,32 +2,21 @@ from pytest import mark
 from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 from honeybadgermpc.progs.mixins.constants import MixinConstants
+from honeybadgermpc.preprocessing import PreProcessedElements
 import asyncio
 
 
 @mark.asyncio
-async def test_empty_shares():
-    n, t = 3, 1
-
-    async def _prog(context):
-        return await context.open_share_array(context.ShareArray([]))
-
-    program_runner = TaskProgramRunner(n, t)
-    program_runner.add(_prog)
-    results = await program_runner.join()
-    assert results == [[] for _ in range(n)]
-
-
-@mark.asyncio
-async def test_open_shares(test_preprocessing):
+async def test_open_shares():
     n, t = 3, 1
     number_of_secrets = 100
-    test_preprocessing.generate("zeros", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_zeros(1000, n, t)
 
     async def _prog(context):
         secrets = []
         for _ in range(number_of_secrets):
-            s = await test_preprocessing.elements.get_zero(context).open()
+            s = await context.preproc.get_zero(context).open()
             assert s == 0
             secrets.append(s)
         print("[%d] Finished" % (context.myid,))
@@ -42,15 +31,15 @@ async def test_open_shares(test_preprocessing):
 
 
 @mark.asyncio
-async def test_open_future_shares(test_preprocessing):
-    n, t = 3, 1
-
-    test_preprocessing.generate("rands", n, t)
-    test_preprocessing.generate("triples", n, t)
+async def test_open_future_shares():
+    n, t = 4, 1
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_rands(1000, n, t)
+    pp_elements.generate_triples(1000, n, t)
 
     async def _prog(context):
-        e1_, e2_ = [test_preprocessing.elements.get_rand(context, t) for _ in range(2)]
-        e1, e2 = await asyncio.gather(*[e1_.open(), e2_.open()])
+        e1_, e2_ = [context.preproc.get_rand(context) for _ in range(2)]
+        e1, e2 = await asyncio.gather(*[e1_.open(), e2_.open()], return_exceptions=True)
 
         s_prod_f = e1_ * e2_
         s_prod_f2 = s_prod_f * e1_

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,17 +1,19 @@
 from pytest import mark
 from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.preprocessing import PreProcessedElements
 import asyncio
 
 
 @mark.asyncio
-async def test_get_triple(test_preprocessing):
+async def test_get_triple():
     n, t = 4, 1
     num_triples = 2
-    test_preprocessing.generate("triples", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_triples(1000, n, t)
 
     async def _prog(ctx):
         for _ in range(num_triples):
-            a_sh, b_sh, ab_sh = test_preprocessing.elements.get_triple(ctx)
+            a_sh, b_sh, ab_sh = ctx.preproc.get_triples(ctx)
             a, b, ab = await a_sh.open(), await b_sh.open(), await ab_sh.open()
             assert a * b == ab
 
@@ -21,14 +23,15 @@ async def test_get_triple(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_cube(test_preprocessing):
+async def test_get_cube():
     n, t = 4, 1
     num_cubes = 2
-    test_preprocessing.generate("cubes", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_cubes(1000, n, t)
 
     async def _prog(ctx):
         for _ in range(num_cubes):
-            a1_sh, a2_sh, a3_sh = test_preprocessing.elements.get_cube(ctx)
+            a1_sh, a2_sh, a3_sh = ctx.preproc.get_cubes(ctx)
             a1, a2, a3 = await a1_sh.open(), await a2_sh.open(), await a3_sh.open()
             assert a1 * a1 == a2
             assert a1 * a2 == a3
@@ -39,14 +42,15 @@ async def test_get_cube(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_zero(test_preprocessing):
+async def test_get_zero():
     n, t = 4, 1
     num_zeros = 2
-    test_preprocessing.generate("zeros", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_zeros(1000, n, t)
 
     async def _prog(ctx):
         for _ in range(num_zeros):
-            x_sh = test_preprocessing.elements.get_zero(ctx)
+            x_sh = ctx.preproc.get_zero(ctx)
             assert await x_sh.open() == 0
 
     program_runner = TaskProgramRunner(n, t)
@@ -55,16 +59,17 @@ async def test_get_zero(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_rand(test_preprocessing):
+async def test_get_rand():
     n, t = 4, 1
     num_rands = 2
-    test_preprocessing.generate("rands", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_rands(1000, n, t)
 
     async def _prog(ctx):
         for _ in range(num_rands):
             # Nothing to assert here, just check if the
             # required number of rands are generated
-            test_preprocessing.elements.get_rand(ctx)
+            ctx.preproc.get_rand(ctx)
 
     program_runner = TaskProgramRunner(n, t)
     program_runner.add(_prog)
@@ -72,13 +77,14 @@ async def test_get_rand(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_bit(test_preprocessing):
+async def test_get_bit():
     n, t = 4, 1
     num_bits = 20
-    test_preprocessing.generate("bits", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_bits(1000, n, t)
 
     async def _prog(ctx):
-        shares = [test_preprocessing.elements.get_bit(ctx) for _ in range(num_bits)]
+        shares = [ctx.preproc.get_bit(ctx) for _ in range(num_bits)]
         x = ctx.ShareArray(shares)
         x_ = await x.open()
         for i in x_:
@@ -90,15 +96,16 @@ async def test_get_bit(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_powers(test_preprocessing):
+async def test_get_powers():
     n, t = 4, 1
+    pp_elements = PreProcessedElements()
     nums, num_powers = 2, 3
 
-    test_preprocessing.generate("powers", n, t, num_powers, nums)
+    pp_elements.generate_powers(num_powers, n, t, nums)
 
     async def _prog(ctx):
         for i in range(nums):
-            powers = test_preprocessing.elements.get_powers(ctx, i)
+            powers = ctx.preproc.get_powers(ctx, i)
             x = await powers[0].open()
             for i, power in enumerate(powers[1:]):
                 assert await power.open() == pow(x, i + 2)
@@ -109,13 +116,14 @@ async def test_get_powers(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_share(test_preprocessing):
+async def test_get_share():
     n, t = 4, 1
     x = 41
-    sid = test_preprocessing.generate("share", n, t, x)
+    pp_elements = PreProcessedElements()
+    sid = pp_elements.generate_share(n, t, x)
 
     async def _prog(ctx):
-        x_sh = test_preprocessing.elements.get_share(ctx, sid)
+        x_sh = ctx.preproc.get_share(ctx, sid)
         assert await x_sh.open() == x
 
     program_runner = TaskProgramRunner(n, t)
@@ -124,12 +132,13 @@ async def test_get_share(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_double_share(test_preprocessing):
+async def test_get_double_share():
     n, t = 9, 2
-    test_preprocessing.generate("double_shares", n, t)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_double_shares(1000, n, t)
 
     async def _prog(ctx):
-        r_t_sh, r_2t_sh = test_preprocessing.elements.get_double_share(ctx)
+        r_t_sh, r_2t_sh = ctx.preproc.get_double_shares(ctx)
         assert r_t_sh.t == ctx.t
         assert r_2t_sh.t == ctx.t * 2
         await r_t_sh.open()
@@ -142,12 +151,13 @@ async def test_get_double_share(test_preprocessing):
 
 
 @mark.asyncio
-async def test_get_share_bits(test_preprocessing):
+async def test_get_share_bits():
     n, t, = 4, 1
-    test_preprocessing.generate("share_bits", n, t, k=1)
+    pp_elements = PreProcessedElements()
+    pp_elements.generate_share_bits(1, n, t)
 
     async def _prog(ctx):
-        share, bits = test_preprocessing.elements.get_share_bits(ctx)
+        share, bits = ctx.preproc.get_share_bits(ctx)
         opened_share = await share.open()
         opened_bits = await asyncio.gather(*[b.open() for b in bits])
         bit_value = int("".join([str(b.value) for b in reversed(opened_bits)]), 2)


### PR DESCRIPTION
# Improving preprocessing

Moving the previous PR (#336) to this so I can base a pr for batched share opening against this.

## What this PR does: 
- Refactors preprocessing to use a mixin model to improve testability and modularity of preprocessing
- Reimplements caching of preprocessing elements to improve performance and reduce testing bugginess
- Refactors the codebase to only access preprocessing elements through a context.
- General refactors to clean up code I came across

## Benefits from this PR:
- Testing time in travis went from ~20-21 minutes down to ~13-14 minutes (approx 2-3 minutes of both measurements are bootstrapping travis, so 18 min => 11 min is the actual testing speedup). 
- Testing time locally on my machine (`pytest -n8 -v`) down from 270-315s => 90-110s
- Tests are much less brittle, with the exception being `asynchromix` tests. All test workers follow good test data isolation practices, as each test worker creates a new temporary directory inside of `sharedata` to store data in that worker to prevent concurrent accesses and improve caching.
  - Added benefit of this is that we are able to preprocess far fewer elements than before (we preprocess about 60k fewer elements of several types if I remember correctly)
  - Far lower memory overhead since the entire preprocessing is only stored in memory once for each worker 
- Cleaner and more intuitive means of interacting with preprocessing.

## Work still to be done:
- Investigate the multiton pattern used for the `PreProcessedElements` class to see if there's a better method of keeping good cache performance (memory + execution time) while being more explicit rather than implicit.
- Unify shared setup and teardown boilerplate throughout remaining tests to use existing fixtures.
- Add documentation on how to use and modify preprocessing in the future
- Work more closely on investigating the differences between preprocessing and fake preprocessing and implementing them.
- Auto-cleanup the `sharedata/` temp directories after all tests have run so this is friendlier on people running outside of docker.
