### PR TITLE
Use absolute paths in root __init__.py

### DIFF
--- a/honeybadgermpc/__init__.py
+++ b/honeybadgermpc/__init__.py
@@ -4,11 +4,16 @@ import logging.config
 import os
 import yaml
 import sys
+from pathlib import Path
+
 from honeybadgermpc.config import HbmpcConfig
 
 
-with open("honeybadgermpc/logging.yaml", "r") as f:
-    os.makedirs("benchmark-logs", exist_ok=True)
+CURRENT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = CURRENT_DIR.parent
+
+with open(CURRENT_DIR / "logging.yaml", "r") as f:
+    os.makedirs(ROOT_DIR / "benchmark-logs", exist_ok=True)
     logging_config = yaml.safe_load(f.read())
     logging.config.dictConfig(logging_config)
     logging.getLogger("asyncio").setLevel(logging.WARNING)


### PR DESCRIPTION
This fixes cases in which the code is invoked from a different location
than it was expected to be, and would cause FileNotFound errors.

Fixes #377

