### PR TITLE
Add more useful traceback message

### DIFF
--- a/honeybadgermpc/utils/misc.py
+++ b/honeybadgermpc/utils/misc.py
@@ -4,13 +4,15 @@ from asyncio import Queue
 import asyncio
 from typing import Callable
 import logging
+import traceback
 
 
 def print_exception_callback(future):
     if future.done():
         ex = future.exception()
         if ex is not None:
-            logging.critical(f"\nException: \n{future} \n{type(ex)} \n{ex}")
+            tb = "".join(traceback.format_exception(None, ex, ex.__traceback__))
+            logging.critical(f"\nException: \n{future} \n{tb})")
             raise ex
 
 


### PR DESCRIPTION
The logging tool in utils/misc.py prints an exception when one is encountered during a background task, such as mixin operations. However, this currently doesn't print the stack trace so there's not much info about the underlying exception

See for instance
https://github.com/amitgtx/HoneyBadgerMPC/commit/c0f6fc7c00e36cb0998882d0689df51d6d3ae051

This PR uses traceback.format_exception to provide a better error message.
Before:
```
2019-12-02 22:17:55,548:[misc.py:14]:[CRITICAL]: 
Exception: 
<Task finished coro=<AsyncMixin.__call__() done, defined at /usr/src/HoneyBadgerMPC/honeybadgermpc/progs/mixins/base.py:41> exception=AssertionError("Preprocessing underrun f<class 'honeybadgermpc.preprocessing.ShareBitsPreProcessing'>")> 
<class 'AssertionError'> 
Preprocessing underrun f<class 'honeybadgermpc.preprocessing.ShareBitsPreProcessing'>
```
After:
```
2019-12-02 22:21:16,195:[misc.py:14]:[CRITICAL]: 
Exception: 
<Task finished coro=<AsyncMixin.__call__() done, defined at /usr/src/HoneyBadgerMPC/honeybadgermpc/progs/mixins/base.py:41> exception=AssertionError()> 
Traceback (most recent call last):
  File "/usr/src/HoneyBadgerMPC/honeybadgermpc/progs/mixins/base.py", line 48, in __call__
    return await cls._prog(context, *args, **kwargs)
  File "/usr/src/HoneyBadgerMPC/honeybadgermpc/progs/mixins/share_comparison.py", line 207, in _prog
    r_bits, c_bits = await LessThan._transform_comparison(context, a_share, b_share)
  File "/usr/src/HoneyBadgerMPC/honeybadgermpc/progs/mixins/share_comparison.py", line 124, in _transform_comparison
    r_b, r_bits = context.preproc.get_share_bits(context)
  File "/usr/src/HoneyBadgerMPC/honeybadgermpc/preprocessing.py", line 668, in get_share_bits
    return self._share_bits.get_value(context)
  File "/usr/src/HoneyBadgerMPC/honeybadgermpc/preprocessing.py", line 101, in get_value
    to_return, used = self._get_value(context, key, *args, **kwargs)
  File "/usr/src/HoneyBadgerMPC/honeybadgermpc/preprocessing.py", line 322, in _get_value
    assert self.count[key] >= 1
AssertionError
```