### PR TITLE
Lower codecov requirements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,10 +9,10 @@ coverage:
   status:
     project:
       default:
-        threshold: 2%
+        threshold: 10%
     patch:
       default:
-        threshold: 1%
+        threshold: 50%
 
   ignore:
     - "docs/*"


### PR DESCRIPTION
Allow the project coverage to drop by 10% and the patch coverage by 50%.

This assumes that we currently wish to benefit from the code coverage measurements for visibility and awareness purposes mainly for the time-being.

The proposed changes will allow a pull request to cause the overall project coverage to drop by 10%, and will allow the actual code changes (patch) to have a coverage that is 50% below the current coverage of the project.

**Example**: Current project coverage is 75%, the proposed settings would:

* allow project coverage to drop to 65%;
* allow patch coverage to drop to 25%.

### Resources
[Codecov docs on `commit status`](https://docs.codecov.io/docs/commit-status)

