### PR TITLE
Apply flake8 import order

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,4 @@ exclude =
 	.eggs/,
         apps/tutorial/
 ignore = E203, E266, E501, W503
+application_import_names = apps,honeybadgermpc,lib_solver

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ jobs:
     install: pip install black
     script: black --check .
   - name: Flake8
-    install: pip install flake8 pep8-naming
-    script: flake8
+    install: pip install flake8 pep8-naming flake8-import-order
+    script: flake8 --count
   - name: Doc8
     install: pip install doc8 pygments
     script: doc8 docs/

--- a/apps/asynchromix/asynchromix.py
+++ b/apps/asynchromix/asynchromix.py
@@ -1,34 +1,35 @@
 """
 Implementation of Asynchromix MPC Coordinator using an EVM blockchain
 """
-from web3 import Web3, HTTPProvider
-import time
 import asyncio
 import logging
-from contextlib import contextmanager
+import os
 import subprocess
+import time
+from contextlib import contextmanager
+
+from ethereum.tools._solidity import compile_code as compile_source
+
+from web3 import HTTPProvider, Web3
+from web3.contract import ConciseContract
+
+from apps.asynchromix.butterfly_network import iterated_butterfly_network
+
+from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
+from honeybadgermpc.mpc import Mpc
+from honeybadgermpc.offline_randousha import generate_bits, generate_triples, randousha
+from honeybadgermpc.polynomial import EvalPoint, polynomials_over
+from honeybadgermpc.preprocessing import PreProcessedElements
+from honeybadgermpc.progs.mixins.constants import MixinConstants
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
 from honeybadgermpc.router import SimpleRouter
 from honeybadgermpc.utils.misc import (
+    flatten_lists,
+    print_exception_callback,
     subscribe_recv,
     wrap_send,
-    print_exception_callback,
-    flatten_lists,
 )
-from honeybadgermpc.field import GF
-from honeybadgermpc.preprocessing import PreProcessedElements
-from honeybadgermpc.polynomial import EvalPoint, polynomials_over
-from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.offline_randousha import randousha
-from honeybadgermpc.offline_randousha import generate_triples
-from honeybadgermpc.offline_randousha import generate_bits
-from honeybadgermpc.mpc import Mpc
-from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
-from honeybadgermpc.progs.mixins.constants import MixinConstants
-from butterfly_network import iterated_butterfly_network
-from ethereum.tools._solidity import compile_code as compile_source
-from web3.contract import ConciseContract
-import os
-
 
 field = GF(Subgroup.BLS12_381)
 

--- a/apps/asynchromix/butterfly_network.py
+++ b/apps/asynchromix/butterfly_network.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
 from math import log
-from honeybadgermpc.preprocessing import PreProcessedElements
 from time import time
+
+from honeybadgermpc.preprocessing import PreProcessedElements
 
 
 async def batch_switch(ctx, xs, ys, n):

--- a/apps/asynchromix/powermixing.py
+++ b/apps/asynchromix/powermixing.py
@@ -1,11 +1,12 @@
 import asyncio
+import logging
 import uuid
 from time import time
-from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.field import GF
+
 from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
+from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.preprocessing import PreProcessedElements
-import logging
 
 
 async def all_secrets_phase1(context, **kwargs):

--- a/apps/asynchromix/solver/solver.py
+++ b/apps/asynchromix/solver/solver.py
@@ -1,6 +1,8 @@
-from lib_solver import ffi, lib
-from honeybadgermpc.elliptic_curve import Subgroup
 import logging
+
+from honeybadgermpc.elliptic_curve import Subgroup
+
+from lib_solver import ffi, lib
 
 
 def int2hexbytes(n):

--- a/apps/asynchromix/solver/solver_build.py
+++ b/apps/asynchromix/solver/solver_build.py
@@ -1,6 +1,7 @@
 """Build helper for C++ extension module used to solve the equation system"""
 
 import os.path
+
 from cffi import FFI
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/apps/tutorial/hbmpc-tutorial-1.py
+++ b/apps/tutorial/hbmpc-tutorial-1.py
@@ -2,17 +2,18 @@
 hbMPC tutorial 1. Running sample MPC programs in the testing simulator
 """
 import asyncio
+
 from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.progs.mixins.dataflow import Share
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements,
 )
-from honeybadgermpc.utils.typecheck import TypeCheck
+from honeybadgermpc.progs.mixins.dataflow import Share
 from honeybadgermpc.progs.mixins.share_arithmetic import (
-    MixinConstants,
     BeaverMultiply,
     BeaverMultiplyArrays,
+    MixinConstants,
 )
+from honeybadgermpc.utils.typecheck import TypeCheck
 
 config = {
     MixinConstants.MultiplyShareArray: BeaverMultiplyArrays(),

--- a/apps/tutorial/hbmpc-tutorial-2.py
+++ b/apps/tutorial/hbmpc-tutorial-2.py
@@ -9,13 +9,14 @@ scripts/launch-tmuxlocal.sh apps/tutorial/hbmpc-tutorial-2.py conf/mpc/local
 """
 import asyncio
 import logging
+
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements,
 )
 from honeybadgermpc.progs.mixins.share_arithmetic import (
-    MixinConstants,
     BeaverMultiply,
     BeaverMultiplyArrays,
+    MixinConstants,
 )
 
 mpc_config = {

--- a/aws/__init__.py
+++ b/aws/__init__.py
@@ -1,6 +1,7 @@
 import logging.config
-import yaml
 import os
+
+import yaml
 
 
 with open("honeybadgermpc/logging.yaml", "r") as f:

--- a/aws/delete_vms.py
+++ b/aws/delete_vms.py
@@ -1,5 +1,6 @@
-import os
 import logging
+import os
+
 from aws.ec2Manager import EC2Manager
 
 

--- a/aws/ec2Manager.py
+++ b/aws/ec2Manager.py
@@ -1,9 +1,12 @@
-import boto3
-import paramiko
-import os.path
 import logging
+import os.path
 from threading import Semaphore
+
 from aws.AWSConfig import AwsConfig
+
+import boto3
+
+import paramiko
 
 
 class EC2Manager:

--- a/aws/run-on-ec2.py
+++ b/aws/run-on-ec2.py
@@ -1,14 +1,14 @@
-import threading
-import uuid
-import os
 import argparse
 import json
 import logging
-from time import time
+import os
+import threading
+import uuid
 from math import log
+from time import time
 
-from aws.ec2Manager import EC2Manager
 from aws.AWSConfig import AwsConfig
+from aws.ec2Manager import EC2Manager
 from aws.s3Manager import S3Manager
 
 

--- a/aws/s3Manager.py
+++ b/aws/s3Manager.py
@@ -1,6 +1,8 @@
-import boto3
 from concurrent.futures import ThreadPoolExecutor
+
 from aws.AWSConfig import AwsConfig
+
+import boto3
 
 
 class S3Manager(object):

--- a/benchmark/test_benchmark_hbavss.py
+++ b/benchmark/test_benchmark_hbavss.py
@@ -1,13 +1,15 @@
-from pytest import mark
+import asyncio
 from contextlib import ExitStack
 from random import randint
-from honeybadgermpc.poly_commit_const import gen_pc_const_crs, PolyCommitConst
-from honeybadgermpc.poly_commit_lin import PolyCommitLin
+
+from pytest import mark
+
 from honeybadgermpc.betterpairing import G1, ZR
-from honeybadgermpc.hbavss import HbAvssLight, HbAvssBatch
-from honeybadgermpc.field import GF
 from honeybadgermpc.elliptic_curve import Subgroup
-import asyncio
+from honeybadgermpc.field import GF
+from honeybadgermpc.hbavss import HbAvssBatch, HbAvssLight
+from honeybadgermpc.poly_commit_const import PolyCommitConst, gen_pc_const_crs
+from honeybadgermpc.poly_commit_lin import PolyCommitLin
 
 
 def get_avss_params(n, t):

--- a/benchmark/test_benchmark_jubjub.py
+++ b/benchmark/test_benchmark_jubjub.py
@@ -1,15 +1,16 @@
 from pytest import mark
+
+from honeybadgermpc.elliptic_curve import Jubjub, Point
 from honeybadgermpc.progs.jubjub import SharedPoint, share_mul
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply,
     BeaverMultiplyArrays,
+    DivideShareArrays,
+    DivideShares,
+    Equality,
     InvertShare,
     InvertShareArray,
-    DivideShares,
-    DivideShareArrays,
-    Equality,
 )
-from honeybadgermpc.elliptic_curve import Jubjub, Point
 
 
 MIXINS = [

--- a/benchmark/test_benchmark_mimc.py
+++ b/benchmark/test_benchmark_mimc.py
@@ -1,15 +1,17 @@
-from pytest import mark
 from random import randint
+
+from pytest import mark
+
 from honeybadgermpc.elliptic_curve import Jubjub
 from honeybadgermpc.progs.mimc import mimc_mpc_batch
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply,
     BeaverMultiplyArrays,
+    DivideShareArrays,
+    DivideShares,
+    Equality,
     InvertShare,
     InvertShareArray,
-    DivideShares,
-    DivideShareArrays,
-    Equality,
 )
 
 CONFIG = {

--- a/benchmark/test_benchmark_polynomial.py
+++ b/benchmark/test_benchmark_polynomial.py
@@ -1,7 +1,9 @@
-from pytest import mark
 from random import randint
+
+from pytest import mark
+
+from honeybadgermpc.ntl.helpers import fft_interpolate, lagrange_interpolate
 from honeybadgermpc.polynomial import get_omega
-from honeybadgermpc.ntl.helpers import lagrange_interpolate, fft_interpolate
 
 cache = {}
 

--- a/benchmark/test_benchmark_preprocessing.py
+++ b/benchmark/test_benchmark_preprocessing.py
@@ -1,4 +1,5 @@
 from pytest import mark
+
 from honeybadgermpc.preprocessing import PreProcessedElements
 
 

--- a/benchmark/test_benchmark_rbc.py
+++ b/benchmark/test_benchmark_rbc.py
@@ -1,8 +1,10 @@
-from honeybadgermpc.broadcast.reliablebroadcast import reliablebroadcast
-from random import randint
-from pytest import mark
 import asyncio
 import os
+from random import randint
+
+from pytest import mark
+
+from honeybadgermpc.broadcast.reliablebroadcast import reliablebroadcast
 
 
 @mark.parametrize(

--- a/benchmark/test_benchmark_reed_solomon.py
+++ b/benchmark/test_benchmark_reed_solomon.py
@@ -1,9 +1,11 @@
-from honeybadgermpc.field import GF
-from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.reed_solomon import GaoRobustDecoder
-from honeybadgermpc.polynomial import EvalPoint, polynomials_over
 from random import randint
+
 from pytest import mark
+
+from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
+from honeybadgermpc.polynomial import EvalPoint, polynomials_over
+from honeybadgermpc.reed_solomon import GaoRobustDecoder
 
 
 @mark.parametrize("t", [1, 3, 5, 10, 25, 33, 50, 100, 256])

--- a/benchmark/test_benchmark_refinement.py
+++ b/benchmark/test_benchmark_refinement.py
@@ -1,4 +1,5 @@
 from pytest import mark
+
 from honeybadgermpc.progs.random_refinement import refine_randoms
 
 

--- a/honeybadgermpc/__init__.py
+++ b/honeybadgermpc/__init__.py
@@ -2,9 +2,9 @@
 
 import logging.config
 import os
-import yaml
-
 from pathlib import Path
+
+import yaml
 
 
 CURRENT_DIR = Path(__file__).resolve().parent

--- a/honeybadgermpc/avss_value_processor.py
+++ b/honeybadgermpc/avss_value_processor.py
@@ -1,9 +1,10 @@
 import asyncio
 import logging
-from pickle import dumps, loads
 from collections import defaultdict
+from pickle import dumps, loads
+
 from honeybadgermpc.broadcast.commonsubset import run_common_subset
-from honeybadgermpc.utils.misc import wrap_send, subscribe_recv
+from honeybadgermpc.utils.misc import subscribe_recv, wrap_send
 from honeybadgermpc.utils.sequencer import Sequencer
 
 

--- a/honeybadgermpc/batch_reconstruction.py
+++ b/honeybadgermpc/batch_reconstruction.py
@@ -1,22 +1,24 @@
 import asyncio
-from .field import GF
-from .polynomial import EvalPoint
 import logging
-from asyncio import Queue
-import time
-from .reed_solomon import (
-    Algorithm,
-    EncoderFactory,
-    DecoderFactory,
-    RobustDecoderFactory,
-)
-from .reed_solomon import IncrementalDecoder
 import random
+import time
+from asyncio import Queue
+
 from honeybadgermpc.utils.misc import (
     chunk_data,
     flatten_lists,
-    transpose_lists,
     subscribe_recv,
+    transpose_lists,
+)
+
+from .field import GF
+from .polynomial import EvalPoint
+from .reed_solomon import (
+    Algorithm,
+    DecoderFactory,
+    EncoderFactory,
+    IncrementalDecoder,
+    RobustDecoderFactory,
 )
 
 

--- a/honeybadgermpc/betterpairing.py
+++ b/honeybadgermpc/betterpairing.py
@@ -1,8 +1,9 @@
-﻿from pypairing import PyFq, PyFq2, PyFq12, PyFqRepr, PyG1, PyG2, PyFr
 import random
 import re
 import struct
 from hashlib import sha256
+
+from pypairing import PyFq, PyFq12, PyFq2, PyFqRepr, PyFr, PyG1, PyG2
 
 # Order of BLS group
 bls12_381_r = 52435875175126190479447740508185965837690552500527637822603658699938581184513  # (# noqa: E501)

--- a/honeybadgermpc/broadcast/avid.py
+++ b/honeybadgermpc/broadcast/avid.py
@@ -1,15 +1,16 @@
 # coding=utf-8
+import asyncio
 import logging
 import math
-import asyncio
-from honeybadgermpc.exceptions import HoneyBadgerMPCError
+
 from honeybadgermpc.broadcast.reliablebroadcast import (
-    encode,
     decode,
-    merkle_tree,
+    encode,
     get_merkle_branch,
+    merkle_tree,
     merkle_verify,
 )
+from honeybadgermpc.exceptions import HoneyBadgerMPCError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.ERROR)

--- a/honeybadgermpc/broadcast/binaryagreement.py
+++ b/honeybadgermpc/broadcast/binaryagreement.py
@@ -1,8 +1,8 @@
 import asyncio
-from collections import defaultdict
 import logging
+from collections import defaultdict
 
-from honeybadgermpc.exceptions import RedundantMessageError, AbandonedNodeError
+from honeybadgermpc.exceptions import AbandonedNodeError, RedundantMessageError
 
 
 logger = logging.getLogger(__name__)

--- a/honeybadgermpc/broadcast/commoncoin.py
+++ b/honeybadgermpc/broadcast/commoncoin.py
@@ -1,9 +1,10 @@
-import logging
-import base64
-from honeybadgermpc.broadcast.crypto.boldyreva import serialize, deserialize1
 import asyncio
-from collections import defaultdict
+import base64
 import hashlib
+import logging
+from collections import defaultdict
+
+from honeybadgermpc.broadcast.crypto.boldyreva import deserialize1, serialize
 
 
 logger = logging.getLogger(__name__)

--- a/honeybadgermpc/broadcast/crypto/boldyreva.py
+++ b/honeybadgermpc/broadcast/crypto/boldyreva.py
@@ -6,10 +6,12 @@ Dependencies:
     based crypto)
 
 """
-from charm.toolbox.pairinggroup import PairingGroup, ZR, G1, G2, pair
-from base64 import encodebytes, decodebytes
-from operator import mul
+from base64 import decodebytes, encodebytes
 from functools import reduce
+from operator import mul
+
+from charm.toolbox.pairinggroup import G1, G2, PairingGroup, ZR, pair
+
 
 # group = PairingGroup('SS512')
 # group = PairingGroup('MNT159')

--- a/honeybadgermpc/broadcast/reliablebroadcast.py
+++ b/honeybadgermpc/broadcast/reliablebroadcast.py
@@ -1,9 +1,10 @@
 # coding=utf-8
-from collections import defaultdict
-import zfec
-import logging
 import hashlib
+import logging
 import math
+from collections import defaultdict
+
+import zfec
 
 
 logger = logging.getLogger(__name__)

--- a/honeybadgermpc/config.py
+++ b/honeybadgermpc/config.py
@@ -10,8 +10,9 @@ This module can be used to:
 Sample config can be found at: conf/sample.ini
 """
 
-from argparse import ArgumentParser
 import json
+from argparse import ArgumentParser
+
 from honeybadgermpc.reed_solomon import Algorithm as RSAlgorithm
 
 

--- a/honeybadgermpc/field.py
+++ b/honeybadgermpc/field.py
@@ -20,8 +20,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with VIFF. If not, see <http://www.gnu.org/licenses/>.
-from gmpy2 import is_prime, mpz
 from random import Random
+
+from gmpy2 import is_prime, mpz
 
 
 class FieldsNotIdentical(Exception):

--- a/honeybadgermpc/hbavss.py
+++ b/honeybadgermpc/hbavss.py
@@ -1,15 +1,16 @@
-import logging
 import asyncio
+import logging
+import time
 from pickle import dumps, loads
-from honeybadgermpc.betterpairing import ZR, interpolate_g1_at_x, G1
-from honeybadgermpc.polynomial import polynomials_over
+
+from honeybadgermpc.betterpairing import G1, ZR, interpolate_g1_at_x
+from honeybadgermpc.broadcast.avid import AVID
+from honeybadgermpc.broadcast.reliablebroadcast import reliablebroadcast
 from honeybadgermpc.poly_commit_const import PolyCommitConst
 from honeybadgermpc.poly_commit_lin import PolyCommitLin
+from honeybadgermpc.polynomial import polynomials_over
 from honeybadgermpc.symmetric_crypto import SymmetricCrypto
-from honeybadgermpc.broadcast.reliablebroadcast import reliablebroadcast
-from honeybadgermpc.broadcast.avid import AVID
-from honeybadgermpc.utils.misc import wrap_send, subscribe_recv
-import time
+from honeybadgermpc.utils.misc import subscribe_recv, wrap_send
 
 
 logger = logging.getLogger(__name__)

--- a/honeybadgermpc/ipc.py
+++ b/honeybadgermpc/ipc.py
@@ -1,15 +1,19 @@
-import logging
 import asyncio
-
-from zmq import ROUTER, DEALER, IDENTITY
-from zmq.asyncio import Context
+import logging
 from pickle import dumps, loads
+
 from psutil import cpu_count
 
+from zmq import DEALER, IDENTITY, ROUTER
+from zmq.asyncio import Context
+
+from honeybadgermpc.config import ConfigVars, HbmpcConfig
 from honeybadgermpc.mpc import Mpc
-from honeybadgermpc.config import HbmpcConfig, ConfigVars
-from honeybadgermpc.utils.misc import wrap_send, subscribe_recv
-from honeybadgermpc.utils.misc import print_exception_callback
+from honeybadgermpc.utils.misc import (
+    print_exception_callback,
+    subscribe_recv,
+    wrap_send,
+)
 
 
 class NodeCommunicator(object):

--- a/honeybadgermpc/mpc.py
+++ b/honeybadgermpc/mpc.py
@@ -1,23 +1,24 @@
-from honeybadgermpc.progs.mixins.dataflow import (
-    Share,
-    ShareArray,
-    ShareFuture,
-    GFElementFuture,
-)
 import asyncio
 import logging
 from collections import defaultdict
-from .polynomial import polynomials_over
+
+from honeybadgermpc.progs.mixins.dataflow import (
+    GFElementFuture,
+    Share,
+    ShareArray,
+    ShareFuture,
+)
+
+from .batch_reconstruction import batch_reconstruct
+from .config import ConfigVars
+from .elliptic_curve import Subgroup
+from .exceptions import HoneyBadgerMPCError
 from .field import GF, GFElement
-from .polynomial import EvalPoint
-from .router import SimpleRouter
+from .polynomial import EvalPoint, polynomials_over
+from .preprocessing import PreProcessedElements
 from .program_runner import ProgramRunner
 from .robust_reconstruction import robust_reconstruct
-from .batch_reconstruction import batch_reconstruct
-from .elliptic_curve import Subgroup
-from .preprocessing import PreProcessedElements
-from .config import ConfigVars
-from .exceptions import HoneyBadgerMPCError
+from .router import SimpleRouter
 from .utils.misc import print_exception_callback
 
 

--- a/honeybadgermpc/offline_randousha.py
+++ b/honeybadgermpc/offline_randousha.py
@@ -1,19 +1,20 @@
-import time
 import asyncio
 import logging
+import time
+
 from honeybadgermpc.config import HbmpcConfig
+from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.exceptions import HoneyBadgerMPCError
 from honeybadgermpc.field import GF
-from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.polynomial import EvalPoint, polynomials_over
-from honeybadgermpc.reed_solomon import EncoderFactory, DecoderFactory
-from honeybadgermpc.mpc import Mpc
 from honeybadgermpc.ipc import ProcessProgramRunner
+from honeybadgermpc.mpc import Mpc
+from honeybadgermpc.polynomial import EvalPoint, polynomials_over
+from honeybadgermpc.reed_solomon import DecoderFactory, EncoderFactory
 from honeybadgermpc.utils.misc import (
-    wrap_send,
-    transpose_lists,
     flatten_lists,
     subscribe_recv,
+    transpose_lists,
+    wrap_send,
 )
 
 

--- a/honeybadgermpc/offline_robust.py
+++ b/honeybadgermpc/offline_robust.py
@@ -1,14 +1,15 @@
 import asyncio
 import logging
-from honeybadgermpc.hbavss import HbAvssLight
-from honeybadgermpc.avss_value_processor import AvssValueProcessor
-from honeybadgermpc.broadcast.crypto.boldyreva import dealer
-from honeybadgermpc.betterpairing import G1, ZR
-from honeybadgermpc.progs.random_refinement import refine_randoms
-from honeybadgermpc.field import GF
-from honeybadgermpc.elliptic_curve import Subgroup
-from honeybadgermpc.utils.misc import wrap_send, subscribe_recv
 from abc import ABC, abstractmethod
+
+from honeybadgermpc.avss_value_processor import AvssValueProcessor
+from honeybadgermpc.betterpairing import G1, ZR
+from honeybadgermpc.broadcast.crypto.boldyreva import dealer
+from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
+from honeybadgermpc.hbavss import HbAvssLight
+from honeybadgermpc.progs.random_refinement import refine_randoms
+from honeybadgermpc.utils.misc import subscribe_recv, wrap_send
 
 
 def get_avss_params(n, t, my_id):

--- a/honeybadgermpc/poly_commit_const.py
+++ b/honeybadgermpc/poly_commit_const.py
@@ -1,4 +1,4 @@
-from honeybadgermpc.betterpairing import ZR, G1, G2, pair
+from honeybadgermpc.betterpairing import G1, G2, ZR, pair
 from honeybadgermpc.polynomial import polynomials_over
 
 

--- a/honeybadgermpc/preprocessing.py
+++ b/honeybadgermpc/preprocessing.py
@@ -1,21 +1,21 @@
-import logging
 import asyncio
-import re
+import logging
 import os
-from os import makedirs, listdir
-from os.path import isfile, join
-from uuid import uuid4
-from random import randint
-from collections import defaultdict
-from itertools import chain
-from enum import Enum
+import re
 from abc import ABC, abstractmethod
+from collections import defaultdict
+from enum import Enum
+from itertools import chain
+from os import listdir, makedirs
+from os.path import isfile, join
+from random import randint
 from shutil import rmtree
+from uuid import uuid4
 
-from .field import GF
-from .polynomial import polynomials_over
-from .ntl import vandermonde_batch_evaluate
 from .elliptic_curve import Subgroup
+from .field import GF
+from .ntl import vandermonde_batch_evaluate
+from .polynomial import polynomials_over
 
 
 class PreProcessingConstants(Enum):

--- a/honeybadgermpc/progs/fixedpoint.py
+++ b/honeybadgermpc/progs/fixedpoint.py
@@ -1,13 +1,14 @@
-import logging
 import asyncio
+import logging
 import time
-from honeybadgermpc.mpc import TaskProgramRunner
+
 from honeybadgermpc.elliptic_curve import Subgroup
 from honeybadgermpc.field import GF
+from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements,
 )
-from honeybadgermpc.progs.mixins.share_arithmetic import MixinConstants, BeaverMultiply
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply, MixinConstants
 
 
 config = {MixinConstants.MultiplyShare: BeaverMultiply()}

--- a/honeybadgermpc/progs/jubjub.py
+++ b/honeybadgermpc/progs/jubjub.py
@@ -1,6 +1,8 @@
 from __future__ import annotations  # noqa: F407
+
 import asyncio
-from honeybadgermpc.elliptic_curve import Jubjub, Point, Ideal
+
+from honeybadgermpc.elliptic_curve import Ideal, Jubjub, Point
 from honeybadgermpc.mpc import Mpc
 
 

--- a/honeybadgermpc/progs/mimc.py
+++ b/honeybadgermpc/progs/mimc.py
@@ -1,4 +1,5 @@
-from math import log, ceil
+from math import ceil, log
+
 from honeybadgermpc.elliptic_curve import Subgroup
 
 # ROUND: iteration time of MiMC encryption function,

--- a/honeybadgermpc/progs/mimc_jubjub_pkc.py
+++ b/honeybadgermpc/progs/mimc_jubjub_pkc.py
@@ -1,5 +1,6 @@
 import asyncio
-from honeybadgermpc.elliptic_curve import Point, Jubjub
+
+from honeybadgermpc.elliptic_curve import Jubjub, Point
 from honeybadgermpc.progs.jubjub import share_mul
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
 

--- a/honeybadgermpc/progs/mimc_symmetric.py
+++ b/honeybadgermpc/progs/mimc_symmetric.py
@@ -1,6 +1,7 @@
 import asyncio
-from honeybadgermpc.field import GF
+
 from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
 from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain
 
 field = GF(Subgroup.BLS12_381)

--- a/honeybadgermpc/progs/mixins/base.py
+++ b/honeybadgermpc/progs/mixins/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+
 from honeybadgermpc.utils.typecheck import TypeCheck
 
 

--- a/honeybadgermpc/progs/mixins/dataflow.py
+++ b/honeybadgermpc/progs/mixins/dataflow.py
@@ -1,10 +1,12 @@
 from __future__ import annotations  # noqa: F407
+
 import asyncio
 from abc import ABC, abstractmethod
+from typing import Callable
+
 from honeybadgermpc.field import GFElement
 from honeybadgermpc.progs.mixins.constants import MixinConstants
 from honeybadgermpc.utils.typecheck import TypeCheck
-from typing import Callable
 
 
 class GFElementFuture(ABC, asyncio.Future):

--- a/honeybadgermpc/progs/mixins/share_arithmetic.py
+++ b/honeybadgermpc/progs/mixins/share_arithmetic.py
@@ -1,9 +1,9 @@
+from asyncio import gather
+
 from honeybadgermpc.progs.mixins.base import AsyncMixin
 from honeybadgermpc.progs.mixins.constants import MixinConstants
-from honeybadgermpc.utils.typecheck import TypeCheck
 from honeybadgermpc.progs.mixins.dataflow import Share, ShareArray
-
-from asyncio import gather
+from honeybadgermpc.utils.typecheck import TypeCheck
 
 
 class BeaverMultiply(AsyncMixin):

--- a/honeybadgermpc/progs/mixins/share_comparison.py
+++ b/honeybadgermpc/progs/mixins/share_comparison.py
@@ -1,9 +1,9 @@
+from asyncio import gather
+
 from honeybadgermpc.progs.mixins.base import AsyncMixin
 from honeybadgermpc.progs.mixins.constants import MixinConstants
-from honeybadgermpc.utils.typecheck import TypeCheck
 from honeybadgermpc.progs.mixins.dataflow import Share, ShareFuture
-
-from asyncio import gather
+from honeybadgermpc.utils.typecheck import TypeCheck
 
 
 class Equality(AsyncMixin):

--- a/honeybadgermpc/progs/triple_refinement.py
+++ b/honeybadgermpc/progs/triple_refinement.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from honeybadgermpc.ntl import vandermonde_batch_evaluate
 from honeybadgermpc.ntl import vandermonde_batch_interpolate
 

--- a/honeybadgermpc/reed_solomon.py
+++ b/honeybadgermpc/reed_solomon.py
@@ -1,18 +1,21 @@
-from honeybadgermpc.ntl import vandermonde_batch_evaluate, vandermonde_batch_interpolate
-from honeybadgermpc.ntl import gao_interpolate
+import logging
+from abc import ABC, abstractmethod
+
+import psutil
+
+from honeybadgermpc.exceptions import HoneyBadgerMPCError
 from honeybadgermpc.ntl import (
-    fft,
-    fft_interpolate,
-    fft_batch_interpolate,
-    fft_batch_evaluate,
-    SetNumThreads,
     AvailableNTLThreads,
+    SetNumThreads,
+    fft,
+    fft_batch_evaluate,
+    fft_batch_interpolate,
+    fft_interpolate,
+    gao_interpolate,
+    vandermonde_batch_evaluate,
+    vandermonde_batch_interpolate,
 )
 from honeybadgermpc.reed_solomon_wb import make_wb_encoder_decoder
-from honeybadgermpc.exceptions import HoneyBadgerMPCError
-import logging
-import psutil
-from abc import ABC, abstractmethod
 
 
 class Encoder(ABC):

--- a/honeybadgermpc/reed_solomon_wb.py
+++ b/honeybadgermpc/reed_solomon_wb.py
@@ -39,8 +39,9 @@
 
 # for solving a linear system
 import logging
+
 from honeybadgermpc.field import GF
-from honeybadgermpc.polynomial import polynomials_over, EvalPoint
+from honeybadgermpc.polynomial import EvalPoint, polynomials_over
 
 
 def make_wb_encoder_decoder(n, k, p, point=None):

--- a/honeybadgermpc/robust_reconstruction.py
+++ b/honeybadgermpc/robust_reconstruction.py
@@ -1,14 +1,14 @@
 from honeybadgermpc.polynomial import polynomials_over
 from honeybadgermpc.reed_solomon import (
     Algorithm,
-    EncoderFactory,
     DecoderFactory,
+    EncoderFactory,
     RobustDecoderFactory,
 )
 from honeybadgermpc.reed_solomon import IncrementalDecoder
 
 # TODO: Abstract this to a separate file instead of importing it from here.
-from honeybadgermpc.batch_reconstruction import fetch_one
+from honeybadgermpc.batch_reconstruction import fetch_one  # noqa I100
 
 
 async def robust_reconstruct(field_futures, field, n, t, point, degree):

--- a/honeybadgermpc/router.py
+++ b/honeybadgermpc/router.py
@@ -1,7 +1,8 @@
 import asyncio
+import logging
 from abc import ABC, abstractmethod
 from functools import partial
-import logging
+
 from honeybadgermpc.utils.typecheck import TypeCheck
 
 

--- a/honeybadgermpc/symmetric_crypto.py
+++ b/honeybadgermpc/symmetric_crypto.py
@@ -1,7 +1,8 @@
-from Crypto.Cipher import AES
-from Crypto import Random
 from hashlib import sha256
 from pickle import dumps, loads
+
+from Crypto import Random
+from Crypto.Cipher import AES
 
 
 class SymmetricCrypto(object):

--- a/honeybadgermpc/utils/misc.py
+++ b/honeybadgermpc/utils/misc.py
@@ -1,10 +1,11 @@
-from .typecheck import TypeCheck
-from collections import defaultdict
-from asyncio import Queue
 import asyncio
-from typing import Callable
 import logging
 import traceback
+from asyncio import Queue
+from collections import defaultdict
+from typing import Callable
+
+from .typecheck import TypeCheck
 
 
 def print_exception_callback(future):

--- a/honeybadgermpc/utils/typecheck.py
+++ b/honeybadgermpc/utils/typecheck.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
-from inspect import Parameter, Signature
 import os
+from inspect import Parameter, Signature
 from typing import _Final
 
 

--- a/pairing/pypairing/__init__.py
+++ b/pairing/pypairing/__init__.py
@@ -2,14 +2,14 @@
 from __future__ import absolute_import
 
 from .pypairing import (
-    PyG1,
+    PyFq,
+    PyFq12,
+    PyFq2,
+    PyFqRepr,
     PyFr,
+    PyG1,
     PyG2,
     py_pairing,
-    PyFq,
-    PyFq2,
-    PyFq12,
-    PyFqRepr,
     vec_sum,
 )
 

--- a/scripts/hbavss_batch.py
+++ b/scripts/hbavss_batch.py
@@ -1,11 +1,13 @@
+import asyncio
+import logging
+import time
+
+from honeybadgermpc.betterpairing import ZR
 from honeybadgermpc.config import HbmpcConfig
 from honeybadgermpc.ipc import ProcessProgramRunner
 from honeybadgermpc.poly_commit_const import gen_pc_const_crs
-from .hbavss import get_avss_params, HbAvssBatch
-from honeybadgermpc.betterpairing import ZR
-import asyncio
-import time
-import logging
+
+from .hbavss import HbAvssBatch, get_avss_params
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.ERROR)

--- a/scripts/hbavss_light.py
+++ b/scripts/hbavss_light.py
@@ -1,10 +1,12 @@
+import asyncio
+import logging
+import time
+
+from honeybadgermpc.betterpairing import ZR
 from honeybadgermpc.config import HbmpcConfig
 from honeybadgermpc.ipc import ProcessProgramRunner
-from .hbavss import get_avss_params, HbAvssLight
-from honeybadgermpc.betterpairing import ZR
-import asyncio
-import time
-import logging
+
+from .hbavss import HbAvssLight, get_avss_params
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.ERROR)

--- a/scripts/stager.py
+++ b/scripts/stager.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-from subprocess import call
-import re
 import argparse
-import yaml
 import logging
+import re
+from subprocess import call
+
+import yaml
 
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s %(message)s", datefmt="%m-%d %H:%M:%S"

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@
 
 import os
 
-from setuptools import setup, find_packages
-from setuptools.extension import Extension
 from Cython.Build import cythonize
+
+from setuptools import find_packages, setup
+from setuptools.extension import Extension
 
 NAME = "honeybadgermpc"
 DESCRIPTION = "honeybadgermpc"
@@ -17,6 +18,7 @@ REQUIRED = ["gmpy2", "zfec", "pycrypto", "cffi", "psutil", "pyzmq"]
 TESTS_REQUIRES = [
     "black",
     "flake8",
+    "flake8-import-order",
     "pep8-naming",
     "pytest",
     "pytest-asyncio",

--- a/tests/crypto/conftest.py
+++ b/tests/crypto/conftest.py
@@ -1,4 +1,5 @@
-from charm.toolbox.pairinggroup import PairingGroup, ZR, G2
+from charm.toolbox.pairinggroup import G2, PairingGroup, ZR
+
 from pytest import fixture
 
 

--- a/tests/crypto/test_boldyreva.py
+++ b/tests/crypto/test_boldyreva.py
@@ -1,7 +1,9 @@
 import pickle
 import random
 from base64 import encodebytes
+
 from pytest import mark
+
 from honeybadgermpc.broadcast.crypto.boldyreva import dealer
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,10 +1,12 @@
-from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.router import SimpleRouter
 import asyncio
 import random
-from tempfile import mkdtemp
-from pytest import fixture
 from os import makedirs
+from tempfile import mkdtemp
+
+from pytest import fixture
+
+from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.router import SimpleRouter
 
 
 @fixture

--- a/tests/progs/mixins/test_share_arithmetic.py
+++ b/tests/progs/mixins/test_share_arithmetic.py
@@ -1,16 +1,18 @@
-from pytest import mark, raises
 from asyncio import gather
 from random import randint
+
+from pytest import mark, raises
+
 from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply,
     BeaverMultiplyArrays,
-    InvertShare,
-    InvertShareArray,
-    DivideShares,
     DivideShareArrays,
+    DivideShares,
     DoubleSharingMultiply,
     DoubleSharingMultiplyArrays,
+    InvertShare,
+    InvertShareArray,
 )
 from honeybadgermpc.progs.mixins.share_comparison import Equality
 

--- a/tests/progs/mixins/test_share_comparison.py
+++ b/tests/progs/mixins/test_share_comparison.py
@@ -1,18 +1,20 @@
-from pytest import mark
 from asyncio import gather
 from random import randint
+
+from pytest import mark
+
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
+from honeybadgermpc.preprocessing import PreProcessedElements
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply,
     BeaverMultiplyArrays,
+    DivideShareArrays,
+    DivideShares,
     InvertShare,
     InvertShareArray,
-    DivideShares,
-    DivideShareArrays,
 )
 from honeybadgermpc.progs.mixins.share_comparison import Equality, LessThan
-from honeybadgermpc.preprocessing import PreProcessedElements
 
 STANDARD_ARITHMETIC_MIXINS = [
     BeaverMultiply(),

--- a/tests/progs/test_fixedpoint.py
+++ b/tests/progs/test_fixedpoint.py
@@ -1,10 +1,12 @@
+import random
+
 from pytest import mark
-from honeybadgermpc.progs.fixedpoint import FixedPoint
+
 from honeybadgermpc.preprocessing import (
     PreProcessedElements as FakePreProcessedElements,
 )
-from honeybadgermpc.progs.mixins.share_arithmetic import MixinConstants, BeaverMultiply
-import random
+from honeybadgermpc.progs.fixedpoint import FixedPoint
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply, MixinConstants
 
 config = {MixinConstants.MultiplyShare: BeaverMultiply()}
 

--- a/tests/progs/test_jubjub.py
+++ b/tests/progs/test_jubjub.py
@@ -1,15 +1,17 @@
 import asyncio
 from copy import copy
+
 from pytest import mark
-from honeybadgermpc.elliptic_curve import Ideal, Point, Jubjub
-from honeybadgermpc.progs.jubjub import SharedPoint, SharedIdeal, share_mul
+
+from honeybadgermpc.elliptic_curve import Ideal, Jubjub, Point
+from honeybadgermpc.progs.jubjub import SharedIdeal, SharedPoint, share_mul
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply,
     BeaverMultiplyArrays,
+    DivideShareArrays,
+    DivideShares,
     InvertShare,
     InvertShareArray,
-    DivideShares,
-    DivideShareArrays,
 )
 from honeybadgermpc.progs.mixins.share_comparison import Equality
 

--- a/tests/progs/test_mimc.py
+++ b/tests/progs/test_mimc.py
@@ -1,8 +1,10 @@
-from pytest import mark
 from random import randint
+
+from pytest import mark
+
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
-from honeybadgermpc.progs.mimc import mimc_mpc, mimc_plain, mimc_mpc_batch
+from honeybadgermpc.progs.mimc import mimc_mpc, mimc_mpc_batch, mimc_plain
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 
 MIXINS = [BeaverMultiply()]

--- a/tests/progs/test_mimc_jubjub_pkc.py
+++ b/tests/progs/test_mimc_jubjub_pkc.py
@@ -1,21 +1,23 @@
-from pytest import mark
 import asyncio
+
+from pytest import mark
+
 from honeybadgermpc.field import GF
 from honeybadgermpc.mpc import Subgroup
+from honeybadgermpc.progs.mimc_jubjub_pkc import (
+    key_generation,
+    mimc_decrypt,
+    mimc_encrypt,
+)
 from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiply,
     BeaverMultiplyArrays,
+    DivideShareArrays,
+    DivideShares,
     InvertShare,
     InvertShareArray,
-    DivideShares,
-    DivideShareArrays,
 )
 from honeybadgermpc.progs.mixins.share_comparison import Equality
-from honeybadgermpc.progs.mimc_jubjub_pkc import (
-    mimc_encrypt,
-    mimc_decrypt,
-    key_generation,
-)
 
 STANDARD_ARITHMETIC_MIXINS = [
     BeaverMultiply(),

--- a/tests/progs/test_mimc_symmetric.py
+++ b/tests/progs/test_mimc_symmetric.py
@@ -1,9 +1,11 @@
-from pytest import mark
 from random import randint
-from honeybadgermpc.field import GF
+
+from pytest import mark
+
 from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
+from honeybadgermpc.progs.mimc_symmetric import mimc_decrypt, mimc_encrypt
 from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
-from honeybadgermpc.progs.mimc_symmetric import mimc_encrypt, mimc_decrypt
 
 MIXINS = [BeaverMultiply()]
 PREPROCESSING = ["rands", "triples", "zeros", "cubes", "bits"]

--- a/tests/progs/test_random_refinement.py
+++ b/tests/progs/test_random_refinement.py
@@ -1,4 +1,5 @@
 from pytest import mark
+
 from honeybadgermpc.progs.random_refinement import refine_randoms
 
 

--- a/tests/progs/test_triple_refinement.py
+++ b/tests/progs/test_triple_refinement.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from pytest import mark
+
 from honeybadgermpc.progs.triple_refinement import refine_triples
 
 

--- a/tests/test_asynchromix.py
+++ b/tests/test_asynchromix.py
@@ -1,11 +1,14 @@
-from pytest import mark
-from honeybadgermpc.preprocessing import PreProcessedElements
-import apps.asynchromix.butterfly_network as butterfly
-from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
-from honeybadgermpc.progs.mixins.constants import MixinConstants
-import apps.asynchromix.powermixing as pm
 from uuid import uuid4
+
+from pytest import mark
+
+import apps.asynchromix.butterfly_network as butterfly
+import apps.asynchromix.powermixing as pm
+
+from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.preprocessing import PreProcessedElements
+from honeybadgermpc.progs.mixins.constants import MixinConstants
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiplyArrays
 
 
 @mark.asyncio

--- a/tests/test_avss_value_processor.py
+++ b/tests/test_avss_value_processor.py
@@ -1,7 +1,9 @@
 import asyncio
-from pytest import mark
 from contextlib import ExitStack
 from pickle import dumps
+
+from pytest import mark
+
 from honeybadgermpc.avss_value_processor import AvssValueProcessor
 from honeybadgermpc.broadcast.crypto.boldyreva import dealer
 

--- a/tests/test_batch_reconstruction.py
+++ b/tests/test_batch_reconstruction.py
@@ -1,6 +1,8 @@
-from pytest import mark
-import pytest
 import asyncio
+
+import pytest
+from pytest import mark
+
 from honeybadgermpc.batch_reconstruction import batch_reconstruct
 from honeybadgermpc.field import GFElement
 from honeybadgermpc.polynomial import EvalPoint

--- a/tests/test_binaryagreement.py
+++ b/tests/test_binaryagreement.py
@@ -1,12 +1,12 @@
 import random
-from asyncio import Queue, Event
-from asyncio import get_event_loop, create_task, gather
+from asyncio import Event, Queue, create_task, gather, get_event_loop
+from collections import defaultdict
+
 from pytest import mark, raises
 
-from honeybadgermpc.broadcast.commoncoin import shared_coin
 from honeybadgermpc.broadcast.binaryagreement import binaryagreement
+from honeybadgermpc.broadcast.commoncoin import shared_coin
 from honeybadgermpc.broadcast.crypto.boldyreva import dealer
-from collections import defaultdict
 
 
 def byzantine_broadcast_router(n, maxdelay=0.005, seed=None, **byzargs):

--- a/tests/test_commoncoin.py
+++ b/tests/test_commoncoin.py
@@ -1,6 +1,8 @@
-import random
 import asyncio
+import random
+
 from pytest import mark
+
 from honeybadgermpc.broadcast.commoncoin import shared_coin
 from honeybadgermpc.broadcast.crypto.boldyreva import dealer
 

--- a/tests/test_commonsubset.py
+++ b/tests/test_commonsubset.py
@@ -1,12 +1,13 @@
-import random
 import asyncio
+import random
+
 from pytest import mark
 
-from honeybadgermpc.broadcast.commoncoin import shared_coin
 from honeybadgermpc.broadcast.binaryagreement import binaryagreement
-from honeybadgermpc.broadcast.reliablebroadcast import reliablebroadcast
+from honeybadgermpc.broadcast.commoncoin import shared_coin
 from honeybadgermpc.broadcast.commonsubset import commonsubset
 from honeybadgermpc.broadcast.crypto.boldyreva import dealer
+from honeybadgermpc.broadcast.reliablebroadcast import reliablebroadcast
 
 
 # Make the threshold signature common coins

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,7 +1,9 @@
-import pytest
 import operator
+
+import pytest
 from pytest import raises
-from honeybadgermpc.field import GF, FieldsNotIdentical
+
+from honeybadgermpc.field import FieldsNotIdentical, GF
 
 
 def test_bool():

--- a/tests/test_hbavss.py
+++ b/tests/test_hbavss.py
@@ -1,17 +1,19 @@
-from pytest import mark
-from random import randint
+import asyncio
 from contextlib import ExitStack
 from pickle import dumps
-from honeybadgermpc.polynomial import polynomials_over
-from honeybadgermpc.poly_commit_const import gen_pc_const_crs
+from random import randint
+
+from pytest import mark
+
 from honeybadgermpc.betterpairing import G1, ZR
-from honeybadgermpc.hbavss import HbAvssLight, HbAvssBatch
+from honeybadgermpc.elliptic_curve import Subgroup
+from honeybadgermpc.field import GF
+from honeybadgermpc.hbavss import HbAvssBatch, HbAvssLight
 from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.poly_commit_const import gen_pc_const_crs
+from honeybadgermpc.polynomial import polynomials_over
 from honeybadgermpc.symmetric_crypto import SymmetricCrypto
 from honeybadgermpc.utils.misc import print_exception_callback
-from honeybadgermpc.field import GF
-from honeybadgermpc.elliptic_curve import Subgroup
-import asyncio
 
 
 def get_avss_params(n, t):

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -1,9 +1,11 @@
-from pytest import mark
-from honeybadgermpc.mpc import TaskProgramRunner
-from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
-from honeybadgermpc.progs.mixins.constants import MixinConstants
-from honeybadgermpc.preprocessing import PreProcessedElements
 import asyncio
+
+from pytest import mark
+
+from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.preprocessing import PreProcessedElements
+from honeybadgermpc.progs.mixins.constants import MixinConstants
+from honeybadgermpc.progs.mixins.share_arithmetic import BeaverMultiply
 
 
 @mark.asyncio

--- a/tests/test_ntl.py
+++ b/tests/test_ntl.py
@@ -1,17 +1,18 @@
-from honeybadgermpc.ntl import (
-    lagrange_interpolate,
-    vandermonde_batch_interpolate,
-    vandermonde_batch_evaluate,
-    fft,
-    fft_interpolate,
-    fft_batch_interpolate,
-    gao_interpolate,
-    evaluate,
-    sqrt_mod,
-    partial_fft,
-    fft_batch_evaluate,
-)
 import random
+
+from honeybadgermpc.ntl import (
+    evaluate,
+    fft,
+    fft_batch_evaluate,
+    fft_batch_interpolate,
+    fft_interpolate,
+    gao_interpolate,
+    lagrange_interpolate,
+    partial_fft,
+    sqrt_mod,
+    vandermonde_batch_evaluate,
+    vandermonde_batch_interpolate,
+)
 
 
 def test_interpolate(galois_field):

--- a/tests/test_offline_randousha.py
+++ b/tests/test_offline_randousha.py
@@ -1,7 +1,9 @@
 import asyncio
+
 from pytest import mark
+
+from honeybadgermpc.offline_randousha import generate_bits, generate_triples, randousha
 from honeybadgermpc.polynomial import EvalPoint
-from honeybadgermpc.offline_randousha import randousha, generate_triples, generate_bits
 from honeybadgermpc.reed_solomon import Algorithm, DecoderFactory
 
 

--- a/tests/test_offline_robust.py
+++ b/tests/test_offline_robust.py
@@ -1,9 +1,11 @@
 import asyncio
-from pytest import mark
 from contextlib import ExitStack
 from random import randint
-from honeybadgermpc.offline_robust import RandomGenerator, TripleGenerator
+
+from pytest import mark
+
 from honeybadgermpc.mpc import TaskProgramRunner
+from honeybadgermpc.offline_robust import RandomGenerator, TripleGenerator
 
 
 @mark.asyncio

--- a/tests/test_poly_commit_const.py
+++ b/tests/test_poly_commit_const.py
@@ -1,6 +1,6 @@
 from honeybadgermpc.betterpairing import G1, ZR
-from honeybadgermpc.polynomial import polynomials_over
 from honeybadgermpc.poly_commit_const import PolyCommitConst, gen_pc_const_crs
+from honeybadgermpc.polynomial import polynomials_over
 
 
 def test_pc_const():

--- a/tests/test_poly_commit_lin.py
+++ b/tests/test_poly_commit_lin.py
@@ -1,7 +1,8 @@
+from random import randint
+
+from honeybadgermpc.betterpairing import G1, ZR
 from honeybadgermpc.poly_commit_lin import PolyCommitLin
 from honeybadgermpc.polynomial import polynomials_over
-from honeybadgermpc.betterpairing import G1, ZR
-from random import randint
 
 
 def test_poly_commit():

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -1,5 +1,6 @@
 from random import randint, shuffle
-from honeybadgermpc.polynomial import get_omega, fnt_decode_step1, fnt_decode_step2
+
+from honeybadgermpc.polynomial import fnt_decode_step1, fnt_decode_step2, get_omega
 
 
 def test_poly_eval_at_k(galois_field, polynomial):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,7 +1,9 @@
+import asyncio
+
 from pytest import mark
+
 from honeybadgermpc.mpc import TaskProgramRunner
 from honeybadgermpc.preprocessing import PreProcessedElements
-import asyncio
 
 
 @mark.asyncio

--- a/tests/test_reed_solomon.py
+++ b/tests/test_reed_solomon.py
@@ -1,17 +1,19 @@
+from unittest.mock import patch
+
 import pytest
+
+from honeybadgermpc.ntl import AvailableNTLThreads
+from honeybadgermpc.polynomial import EvalPoint
+from honeybadgermpc.reed_solomon import DecoderFactory, EncoderFactory
+from honeybadgermpc.reed_solomon import DecoderSelector, EncoderSelector
 from honeybadgermpc.reed_solomon import (
-    VandermondeEncoder,
-    FFTEncoder,
-    VandermondeDecoder,
     FFTDecoder,
+    FFTEncoder,
     GaoRobustDecoder,
+    VandermondeDecoder,
+    VandermondeEncoder,
     WelchBerlekampRobustDecoder,
 )
-from honeybadgermpc.polynomial import EvalPoint
-from honeybadgermpc.reed_solomon import EncoderFactory, DecoderFactory
-from honeybadgermpc.reed_solomon import EncoderSelector, DecoderSelector
-from honeybadgermpc.ntl import AvailableNTLThreads
-from unittest.mock import patch
 
 
 @pytest.fixture

--- a/tests/test_reed_solomon_wb.py
+++ b/tests/test_reed_solomon_wb.py
@@ -1,4 +1,5 @@
 import random
+
 from honeybadgermpc.reed_solomon_wb import make_wb_encoder_decoder
 
 

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,5 +1,7 @@
+from random import randint, shuffle
+
 from pytest import mark, raises
-from random import shuffle, randint
+
 from honeybadgermpc.utils.sequencer import Sequencer
 
 

--- a/tests/test_symmetric_crypto.py
+++ b/tests/test_symmetric_crypto.py
@@ -1,4 +1,5 @@
 import uuid
+
 from honeybadgermpc.symmetric_crypto import SymmetricCrypto
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
-from pytest import mark
-from honeybadgermpc.utils.misc import wrap_send
-from random import randint
 import asyncio
+from random import randint
+
+from pytest import mark
+
+from honeybadgermpc.utils.misc import wrap_send
 
 
 def test_wrap_send():

--- a/tests/utils/test_typecheck.py
+++ b/tests/utils/test_typecheck.py
@@ -1,6 +1,8 @@
-from honeybadgermpc.utils.typecheck import TypeCheck
-from pytest import raises
 from typing import Callable
+
+from pytest import raises
+
+from honeybadgermpc.utils.typecheck import TypeCheck
 
 
 def test_type_check_callable():


### PR DESCRIPTION
This will help having a consistent style and structure for imports.

The style used is the default one which is the one referred to as
`cryptography`.

See https://github.com/PyCQA/flake8-import-order for more information.

Resolves #392

**Editors**
`flake8-import-order` is added to `setup.py` and re-installing the project (e.g.: `docker-compose build` or `pip install -e .[dev]`) should make the plugin available to your editor. 