### PR TITLE
Preview docs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      - image: initc3/honeybadgermpc-deps@sha256:46902d869ea881d7b00b72ff6accf2558a5e15849da5fa5cc722b4ff82a507f8
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - cache-pip-{{ .Branch }}
+            # fallback to using the latest cache if no exact match is found
+            - cache-pip-
+
+      - run:
+          name: install dependencies
+          # The "--editable" option is needed until we resolve issue #377.
+          # See https://github.com/initc3/HoneyBadgerMPC/issues/377 for more info.
+          command: pip install --editable .[docs]
+
+      - save_cache:
+          paths:
+            - "/opt/venv"
+            - "~/.cache/pip"
+          key: cache-pip-{{ .Branch }}-{{ .BuildNum }}
+
+      - run:
+          name: build docs
+          command: sphinx-build -M html docs docs/_build -c docs -W
+      - store_artifacts:
+          path: docs/_build/html
+          destination: docs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,12 +18,9 @@
     performance
     roadmap
 
-.. toctree::
-    :maxdepth: 1
-    :caption: Guides
-
-    guides/acs-evm
-    guides/passive
+.. .. toctree::
+..     :maxdepth: 1
+..     :caption: Guides
 
 .. .. note:: A tutorial should show some primary use cases in more detail. The
     reader will follow a step-by-step procedure to set-up a working prototype.


### PR DESCRIPTION
When pull requests make modifications to the documentation it is not necessarily easy to know whether the documentation renders properly. Using CircleCI it is possible to store and view the generated docs for a pull request.

For example the build for this PR can be found at https://app.circleci.com/jobs/github/sbellem/HoneyBadgerMPC/6 and the generated docs are under the artifacts at https://app.circleci.com/jobs/github/sbellem/HoneyBadgerMPC/6/artifacts. Selecting the `docs/index.html` brings one to the rendered docs: https://6-141841687-gh.circle-artifacts.com/0/docs/index.html.  