### PR TITLE
add citation for fixedpoint.py

### DIFF
--- a/honeybadgermpc/progs/fixedpoint.py
+++ b/honeybadgermpc/progs/fixedpoint.py
@@ -11,6 +11,11 @@ from honeybadgermpc.progs.mixins.share_arithmetic import MixinConstants, BeaverM
 
 
 config = {MixinConstants.MultiplyShare: BeaverMultiply()}
+"""
+Secure Computation With Fixed-Point Numbers
+Catrina and Saxena
+http://www.ifca.ai/pub/fc10/31_47.pdf
+"""
 
 
 # Fixed Point parameters


### PR DESCRIPTION
This citation doesn't seem to have made it into the fixedpoint.py program that got merged
Secure Computation With Fixed-Point Numbers
Catrina and Saxena
http://www.ifca.ai/pub/fc10/31_47.pdf