### PR TITLE
Add check for docstring convention (PEP 257)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,10 @@ jobs:
   - name: Flake8
     install: pip install flake8 pep8-naming flake8-import-order
     script: flake8 --count
-  - name: Doc8
+  - name: Docstrings
+    install: pip install pydocstyle
+    script: pydocstyle --count apps/ aws/ honeybadgermpc/
+  - name: Doc8 - rst files
     install: pip install doc8 pygments
     script: doc8 docs/
   - stage: Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ./Makefile:/usr/src/HoneyBadgerMPC/Makefile
       - ./pytest.ini:/usr/src/HoneyBadgerMPC/pytest.ini
       - ./setup.py:/usr/src/HoneyBadgerMPC/setup.py
+      - ./setup.cfg:/usr/src/HoneyBadgerMPC/setup.cfg
       - ./pairing/pypairing/__init__.py:/usr/src/HoneyBadgerMPC/pairing/pypairing/__init__.py
       - ./pairing/src:/usr/src/HoneyBadgerMPC/pairing/src
       - ./pairing/benches:/usr/src/HoneyBadgerMPC/pairing/benches

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pydocstyle]
+# Error codes docs: http://www.pydocstyle.org/en/5.0.2/error_codes.html
+# Conventions docs: http://www.pydocstyle.org/en/5.0.2/error_codes.html#default-conventions
+convention=pep257
+add_ignore=D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D208,D210,D400,D401,D402,D403

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ DOCS_REQUIRE = [
     "sphinx_rtd_theme",
     "sphinx_tabs",
     "doc8",
+    "pydocstyle",
     "recommonmark",
 ]
 


### PR DESCRIPTION
**What is this?**
Python has a style guide for docstrings in [PEP 257](https://www.python.org/dev/peps/pep-0257/). [`pydocstyle`](https://github.com/PyCQA/pydocstyle/) is a tool to check the docstrings according to the conventions in [PEP 257](https://www.python.org/dev/peps/pep-0257/). 

The configuration is in `setup.cfg` under the `[pydocstyle]` section:

```cfg
[pydocstyle]
convention=pep257
add_ignore=D100,D101,D102,D103,D104,D105,D107,D200,D202,D205,D208,D210,D400,D401,D402,D403
```
 
A complete list of error codes is at http://www.pydocstyle.org/en/5.0.2/error_codes.html.

### Goal and direction
The goal of this pull request is to introduce the usage of `pydocstyle` to check docstrings but meanwhile tolerating a lot of "[errors](http://www.pydocstyle.org/en/5.0.2/error_codes.html)" with the intention of gradually fixing these errors and eventually requiring the [numpy](https://numpydoc.readthedocs.io/en/latest/format.html) style of docstrings.