### PR TITLE
Fix import errors in some benchmark/test_*

### DIFF
--- a/benchmark/test_benchmark_jubjub.py
+++ b/benchmark/test_benchmark_jubjub.py
@@ -7,10 +7,10 @@ from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiplyArrays,
     DivideShareArrays,
     DivideShares,
-    Equality,
     InvertShare,
     InvertShareArray,
 )
+from honeybadgermpc.progs.mixins.share_comparison import Equality
 
 
 MIXINS = [

--- a/benchmark/test_benchmark_mimc.py
+++ b/benchmark/test_benchmark_mimc.py
@@ -9,10 +9,10 @@ from honeybadgermpc.progs.mixins.share_arithmetic import (
     BeaverMultiplyArrays,
     DivideShareArrays,
     DivideShares,
-    Equality,
     InvertShare,
     InvertShareArray,
 )
+from honeybadgermpc.progs.mixins.share_comparison import Equality
 
 CONFIG = {
     BeaverMultiply.name: BeaverMultiply(),

--- a/benchmark/test_benchmark_polynomial.py
+++ b/benchmark/test_benchmark_polynomial.py
@@ -2,7 +2,7 @@ from random import randint
 
 from pytest import mark
 
-from honeybadgermpc.ntl.helpers import fft_interpolate, lagrange_interpolate
+from honeybadgermpc.ntl import fft_interpolate, lagrange_interpolate
 from honeybadgermpc.polynomial import get_omega
 
 cache = {}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -194,11 +194,8 @@ def test_runner():
 
 @fixture
 def benchmark_runner(benchmark):
-    from honeybadgermpc.preprocessing import PreProcessedElements
-
     def _benchmark_runner(prog, n=4, t=1, to_generate=[], k=1000, mixins=[]):
-        pp_elements = PreProcessedElements()
-        _preprocess(pp_elements, n, t, k, to_generate)
+        _preprocess(n, t, k, to_generate)
 
         config = _build_config(mixins)
         program_runner = TaskProgramRunner(n, t, config)


### PR DESCRIPTION
* Import paths have changed for the `Equality` share comparison class.
* `ntl` helper module changed path.

### NOTES
I am not sure what is the expected approximate time to run the benchmark tests, but if it was reasonable we could add these to Travis CI.

As I am writing this, one test (`test_benchmark_hbavss_dealer[33-5]`) appears to hang, or perhaps it just takes a long time:

**UPDATE**: the test in question, was just taking a long time to run ...

```shell
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-8] FAILED              [  0%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-16] FAILED             [  1%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-32] FAILED             [  1%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-64] FAILED             [  2%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-128] FAILED            [  2%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-256] FAILED            [  3%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-512] FAILED            [  3%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[4-1-1024] FAILED           [  4%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-8] FAILED              [  4%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-16] FAILED             [  5%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-32] FAILED             [  5%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-64] FAILED             [  6%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-128] FAILED            [  6%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-256] FAILED            [  7%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-512] FAILED            [  7%]
benchmark/test_benchmark_batch_opening.py::test_benchmark_batch_opening[7-2-1024] FAILED           [  8%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[1-5] PASSED                  [  8%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[3-5] PASSED                  [  9%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[5-5] PASSED                  [  9%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[16-5] PASSED                 [ 10%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[33-5] PASSED                 [ 10%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[85-5] PASSED                 [ 11%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[1-25] PASSED                 [ 11%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[3-25] PASSED                 [ 12%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[5-25] PASSED                 [ 12%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[16-25] PASSED                [ 13%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[33-25] PASSED                [ 13%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[85-25] PASSED                [ 14%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[1-50] PASSED                 [ 14%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[3-50] PASSED                 [ 15%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[5-50] PASSED                 [ 15%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[16-50] PASSED                [ 16%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[33-50] PASSED                [ 16%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[85-50] PASSED                [ 17%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[1-100] PASSED                [ 17%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[3-100] PASSED                [ 18%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[5-100] PASSED                [ 18%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[16-100] PASSED               [ 19%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[33-100] PASSED               [ 19%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_lite_dealer[85-100] PASSED               [ 20%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_dealer[1-5] PASSED                       [ 20%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_dealer[3-5] PASSED                       [ 21%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_dealer[5-5] PASSED                       [ 21%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_dealer[16-5] PASSED                      [ 22%]
benchmark/test_benchmark_hbavss.py::test_benchmark_hbavss_dealer[33-5]
```