### PR TITLE
Benchmark runner to run task once per iteration

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -202,10 +202,10 @@ def benchmark_runner(benchmark):
 
         config = _build_config(mixins)
         program_runner = TaskProgramRunner(n, t, config)
-        program_runner.add(prog)
         loop = asyncio.get_event_loop()
 
         def _work():
+            program_runner.add(prog)            
             loop.run_until_complete(program_runner.join())
 
         benchmark(_work)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -204,10 +204,13 @@ def benchmark_runner(benchmark):
         program_runner = TaskProgramRunner(n, t, config)
         loop = asyncio.get_event_loop()
 
+        def _setup():
+            program_runner.tasks.clear()
+            program_runner.add(prog)
+
         def _work():
-            program_runner.add(prog)            
             loop.run_until_complete(program_runner.join())
 
-        benchmark(_work)
+        benchmark(_work, setup=_setup)
 
     return _benchmark_runner


### PR DESCRIPTION
Previously the benchmark runner would only run the task once. The task is added once, and in each iteration we would `join` on the tasks, but since the task is already completed this would resolve right away
```
@fixture
def benchmark_runner(benchmark):
    def _benchmark_runner(prog, n=4, t=1, to_generate=[], k=1000, mixins=[]):
        _preprocess(n, t, k, to_generate)
        config = _build_config(mixins)
        program_runner = TaskProgramRunner(n, t, config)
        program_runner.add(prog)
        loop = asyncio.get_event_loop()
        def _work():
            loop.run_until_complete(program_runner.join())
        benchmark.pedantic(_work, iterations=100, rounds=10, warmup_rounds=10)
    return _benchmark_runner
```