### PR TITLE
Fix flake8 errors with new version >= 3.8

### DIFF
--- a/apps/asynchromix/powermixing.py
+++ b/apps/asynchromix/powermixing.py
@@ -122,11 +122,11 @@ async def async_mixing(n, t, k):
 
 
 async def build_newton_solver():
-    await run_command_sync(f"python apps/shuffle/solver/solver_build.py")
+    await run_command_sync("python apps/shuffle/solver/solver_build.py")
 
 
 async def build_powermixing_cpp_code():
-    await run_command_sync(f"make -C apps/shuffle/cpp")
+    await run_command_sync("make -C apps/shuffle/cpp")
 
 
 async def async_mixing_in_processes(network_info, n, t, k, run_id, node_id):

--- a/aws/run-on-ec2.py
+++ b/aws/run-on-ec2.py
@@ -183,10 +183,10 @@ def get_powermixing_setup_commands(max_k, runid, s3manager, instance_ids):
 
     setup_commands = []
     total_time = 0
-    logging.info(f"Uploading input files to AWS S3.")
+    logging.info("Uploading input files to AWS S3.")
 
     for i, instance_id in enumerate(instance_ids):
-        url = s3manager.upload_file(f"aws/download_input.sh")
+        url = s3manager.upload_file("aws/download_input.sh")
         commands = [
             "sudo docker pull %s" % (AwsConfig.DOCKER_IMAGE_PATH),
             f"curl -sSO {url}",

--- a/benchmark/test_benchmark_rbc.py
+++ b/benchmark/test_benchmark_rbc.py
@@ -82,7 +82,7 @@ async def rbc(params):
     (sends, recvs, t, n, msg) = params
     rbc_tasks = [None] * n
     dealer_id = randint(0, n - 1)
-    tag = f"RBC"
+    tag = "RBC"
 
     for i in range(n):
         if i == dealer_id:
@@ -101,5 +101,5 @@ async def rbc(params):
 async def rbc_dealer(params):
 
     (sends, recvs, t, n, msg) = params
-    tag = f"RBC"
+    tag = "RBC"
     await reliablebroadcast(tag, 0, n, t, 0, msg, recvs[0], sends[0], client_mode=True)

--- a/honeybadgermpc/broadcast/crypto/boldyreva.py
+++ b/honeybadgermpc/broadcast/crypto/boldyreva.py
@@ -64,7 +64,7 @@ def polynom_eval(x, coefficients):
 class TBLSPublicKey(object):
     """ """
 
-    def __init__(self, l, k, vk, vks):
+    def __init__(self, l, k, vk, vks):  # noqa E741
         """ """
         self.l = l  # noqa: E741
         self.k = k
@@ -136,7 +136,7 @@ class TBLSPublicKey(object):
 class TBLSPrivateKey(TBLSPublicKey):
     """ """
 
-    def __init__(self, l, k, vk, vks, sk, i):
+    def __init__(self, l, k, vk, vks, sk, i):  # noqa E741
         """ """
         super(TBLSPrivateKey, self).__init__(l, k, vk, vks)
         assert 0 <= i < self.l

--- a/honeybadgermpc/offline_randousha.py
+++ b/honeybadgermpc/offline_randousha.py
@@ -183,7 +183,7 @@ async def generate_triples(n, t, k, my_id, _send, _recv, field):
 
     # TODO: compute triples through degree reduction
     send, recv = _get_send_recv("opening")
-    ctx = Mpc(f"mpc:opening", n, t, my_id, send, recv, prog, {})
+    ctx = Mpc("mpc:opening", n, t, my_id, send, recv, prog, {})
 
     result = await ctx._run()
     subscribe_recv_task.cancel()
@@ -225,7 +225,7 @@ async def generate_bits(n, t, k, my_id, _send, _recv, field):
 
     # TODO: compute triples through degree reduction
     send, recv = _get_send_recv("opening")
-    ctx = Mpc(f"mpc:opening", n, t, my_id, send, recv, prog, {})
+    ctx = Mpc("mpc:opening", n, t, my_id, send, recv, prog, {})
     result = await ctx._run()
     # print(f'[{my_id}] Generate triples complete')
     subscribe_recv_task.cancel()

--- a/tests/test_ntl.py
+++ b/tests/test_ntl.py
@@ -111,7 +111,8 @@ def test_fft_batch_evaluate_big(galois_field, galois_field_roots):
         for j in range(k):
             x = pow(omega, j, p)
             assert (
-                fft_rep[i][j] == sum(coeffs[i][l] * pow(x, l, p) for l in range(d)) % p
+                fft_rep[i][j]
+                == sum(coeffs[i][l] * pow(x, l, p) for l in range(d)) % p  # noqa E741
             )
 
 


### PR DESCRIPTION
Fixes #446

f-strings with no placeholder are not allowed, e.g.: `f'the color is yellow"` must be either `f"the color is {color}"` or `"the color is yellow"` ...

variables `l` are flagged as being ambiguous ... [PEP 8](https://www.python.org/dev/peps/pep-0008/#names-to-avoid) is enforced:

> Never use the characters 'l' (lowercase letter el), 'O' (uppercase letter oh), or 'I' (uppercase letter eye) as single character variable names.
>
> In some fonts, these characters are indistinguishable from the numerals one and zero. When tempted to use 'l', use 'L' instead.

I did not make modifications there, but ignored the error by adding `# noqa E741`.