### PR TITLE
Improve the documentation generation workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ docs: ## generate Sphinx HTML documentation
 	docker-compose --file docs.yml run --rm build make -C docs clean
 	docker-compose --file docs.yml up build
 	docker-compose --file docs.yml stop view
-	docker-compose --file docs.yml up --detach view
+	docker-compose --file docs.yml up -d view
 
 docs-browser: docs ## generate Sphinx HTML documentation
 	$(BROWSER) index.html
@@ -84,7 +84,7 @@ servedocs: docs-browser ## compile the docs watching for changes
 	docker-compose --file docs.yml up watch
 
 servedocs-detach: docs-browser ## compile the docs watching for changes
-	docker-compose --file docs.yml up --detach watch
+	docker-compose --file docs.yml up -d watch
 
 servedocs-stop:
 	docker-compose --file docs.yml stop watch

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 .PHONY: clean clean-test clean-pyc clean-build docs help
 .DEFAULT_GOAL := help
+
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
+
 try:
 	from urllib import pathname2url
 except:
 	from urllib.request import pathname2url
 
-webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+webbrowser.open("http://localhost:58888/" + sys.argv[1])
 endef
 export BROWSER_PYSCRIPT
 
@@ -61,13 +63,38 @@ coverage: ## check code coverage quickly with the default Python
 	pytest -v -n auto --cov=honeybadgermpc --cov-report term --cov-report html
 	$(BROWSER) htmlcov/index.html
 
-docs: ## generate Sphinx HTML documentation, including API docs
+docs-local: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
-servedocs: docs ## compile the docs watching for changes
+servedocs-local: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
+
+docs: ## generate Sphinx HTML documentation
+	docker-compose --file docs.yml run --rm build make -C docs clean
+	docker-compose --file docs.yml up build
+	docker-compose --file docs.yml stop view
+	docker-compose --file docs.yml up --detach view
+
+docs-browser: docs ## generate Sphinx HTML documentation
+	$(BROWSER) index.html
+
+servedocs: docs-browser ## compile the docs watching for changes
+	docker-compose --file docs.yml up watch
+
+servedocs-detach: docs-browser ## compile the docs watching for changes
+	docker-compose --file docs.yml up --detach watch
+
+servedocs-stop:
+	docker-compose --file docs.yml stop watch
+	docker-compose --file docs.yml stop view
+
+docs-follow-logs:
+	docker-compose --file docs.yml logs --follow watch
+
+docs-logs:
+	docker-compose --file docs.yml logs watch
 
 release: clean ## package and upload a release
 	twine upload dist/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.4'
 
 services:
   honeybadgermpc:
+    image: honeybadgermpc-local
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs.yml
+++ b/docs.yml
@@ -1,18 +1,27 @@
 version: '3'
 
 services:
-  builddocs:
+  build:
+    image: honeybadgermpc-local
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        BUILD: docs
     volumes:
       - .:/usr/src/HoneyBadgerMPC
     environment:
       - O=-W --keep-going
     command: make -C docs html
-  viewdocs:
+  watch:
+    image: honeybadgermpc-local
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/usr/src/HoneyBadgerMPC
+    environment:
+      - O=-W --keep-going
+    command: watchmedo shell-command -p '*.rst' -c 'make -C docs html' -R -D .
+  view:
     image: nginx
     ports:
       - '58888:80'

--- a/docs/development/getting-started.rst
+++ b/docs/development/getting-started.rst
@@ -280,75 +280,104 @@ Flake8 configuration file
 `Configuration for flake8`_ is under the :file:`.flake8` file.
 
 
-
 Building and viewing the documentation
 --------------------------------------
 Documentation for ``honeybadgermpc`` is located under the :file:`docs/`
 directory. `Sphinx`_ is used to build the documentation, which is written
 using the markup language `reStructuredText`_.
 
-The :file:`docker-compose.yml` can be used to quickly build the docs and view
-them.
+The :file:`Makefile` can be used to build and serve the docs.
 
-**To build the docs:**
+Prerequisite: up-to-date docker image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``make`` targets to build the documentation do not update or rebuild
+the docker image (``honeybadgermpc-local``) being used, so make sure you have
+an up-to-date image.
 
-.. # run `O=-W --keep-going make -C docs html` in a container, which will
-.. # write the html docs locally under docs/_build/html
+To check whether the ``honeybadgermpc-local`` image was recently created:
+
 .. code-block:: shell-session
 
-    $ docker-compose up builddocs
+    $ docker images honeybadgermpc-local
+    REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
+    honeybadgermpc-local   latest              628fdc4f0200        18 minutes ago      2.58GB
 
-**To view the docs**:
+To (re)build it:
 
-.. # start nginx which is used to host the docs locally
 .. code-block:: shell-session
 
-    $ docker-compose up -d viewdocs
+    $ docker-compose build
 
-Visit http://localhost:58888/ in a web browser.
+Build, serve and view the docs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: shell-session
+
+    $ make servedocs
+
+This will build the docs and open a tab or window in your default web browser
+at http://localhost:58888/.
+
+When you make and save changes to ``.rst`` files the documentation will be
+rebuilt automatically. You should see the output in the terminal where you
+ran ``make servedocs``.
+
+.. note:: The automatic documentation generation uses `watchdog`_. You can
+    look at the `docs.yml`_ file to understand better how it works.
+
+If you prefer you can run the automatic documentation generation in the
+background with:
+
+.. code-block:: shell-session
+
+    $ make servedocs-detach
+
+To monitor the output of the documentation generation you can follow
+the logs like so:
+
+.. code-block:: shell-session
+
+    $ make docs-follow-logs
+
+To simply get a dump of the latest logs:
+
+.. code-block:: shell-session
+
+    $ make docs-logs
+
+To stop serving and watching the docs:
+
+.. code-block:: shell-session
+
+    $ make servedocs-stop
 
 
-.. tip:: To view the port mapping you can use the command:
+Just building the docs
+""""""""""""""""""""""
 
-    .. code-block:: shell-session
+.. code-block:: shell-session
 
-        $ docker-compose port viewdocs 80
+    $ make docs
 
-    or, alternatively
+You then have to go to http://localhost:58888/ in a web browser.
 
-    .. code-block:: shell-session
+To build the docs and have the browser automatically launch at
+http://localhost:58888/ run:
 
-        $ docker-compose ps viewdocs
+.. code-block:: shell-session
 
+    $ make docs-browser
 
-.. tip:: One may get a ``403 Forbidden`` error when trying to view the docs
-    at http://localhost:58888/. This may because the generated html docs were
-    removed. Using the ``make clean`` command under the :file:`docs/`
-    directory, e.g.:
-
-    .. code-block:: shell-session
-
-        $ docker-compose run --rm builddocs make -C docs clean
-
-    wipes out the :file:`_build/` directory, and one has to restart the
-    ``viewdocs`` (``nginx``) service, i.e.:
-
-    .. code-block:: shell-session
-
-        $ docker-compose restart viewdocs
-
-    and then re-build the docs:
-
-    .. code-block:: shell-session
-
-        $ docker-compose up builddocs
-
-    Or vice-versa: build the docs and restart the server.
 
 Alternative ways to build and view the docs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To build the documentation, one can use the :file:`Makefile` under the
-:file:`docs/` directory:
+There are many other ways to generate the documentation. The ``Makefile``
+targets and ``docker-compose`` ``docs.yml`` file are provided for
+convenience.
+
+If you prefer not to use the ``Makefile`` and/or the ``docker-compose``
+``docs.yml`` file, then you can use the :file:`Makefile`, provided by
+Sphinx, under the :file:`docs/` directory:
 
 .. code-block:: shell-session
 
@@ -376,7 +405,6 @@ building the docs when a warning occurs:
 .. code-block:: shell-session
 
     $ O='-W --keep-going' make html
-
 
 By default the generated docs are under :file:`docs/_build/html/` and one
 can view them using a browser, e.g.:
@@ -418,3 +446,5 @@ can view them using a browser, e.g.:
 .. _The Hitchhiker’s Guide to Python: https://docs.python-guide.org/
 .. _black: https://github.com/ambv/black
 .. _pre-commit: https://pre-commit.com
+.. _watchdog: https://github.com/gorakhargosh/watchdog
+.. _docs.yml: https://github.com/initc3/HoneyBadgerMPC/blob/dev/docs.yml


### PR DESCRIPTION
Re-work the documentation workflow to use the `Makefile` and `docker-compose` to ease the documentation generation.

Basically, all that should be needed is to run

```shell
$ make servedocs
```

which will
* build the docs
* serve the docs at http://localhost:58888
* use watchdog to monitor changes to `.rst` files in a background process and rebuild the docs when changes are saved

The documentation on how to generate the documentation was also updated to reflect these changes. A preview can be seen at https://101-141841687-gh.circle-artifacts.com/0/docs/development/getting-started.html#building-and-viewing-the-documentation.


